### PR TITLE
fix: Remove github readme from DA tile

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -1,3878 +1,3880 @@
 {
-    "products": [
+  "products": [
+    {
+      "label": "DevSecOps CD Toolchain",
+      "name": "deploy-arch-devsecops-cd-toolchain",
+      "version": "1.0.1",
+      "product_kind": "solution",
+      "tags": [
+        "enterprise_app"
+      ],
+      "keywords": [
+        "DevSecOps Toolchain Compliance",
+        "DevOps",
+        "DevOps Pipeline",
+        "Pipelines",
+        "Terraform",
+        "Security",
+        "Compliance"
+      ],
+      "offering_icon_url": "https://globalcatalog.cloud.ibm.com/api/v1/1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc/artifacts/solution.svg",
+      "flavors": [
         {
-            "label": "DevSecOps CD Toolchain",
-            "name": "deploy-arch-devsecops-cd-toolchain",
-            "version": "1.0.1",
-            "product_kind": "solution",
-            "tags": [
-                "enterprise_app"
-            ],
-            "keywords": [
-                "DevSecOps Toolchain Compliance",
-                "DevOps",
-                "DevOps Pipeline",
-                "Pipelines",
-                "Terraform",
-                "Security",
-                "Compliance"
-            ],
-            "offering_icon_url": "https://globalcatalog.cloud.ibm.com/api/v1/1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc/artifacts/solution.svg",
-            "flavors": [
-                {
-                    "label": "Deploy to Kubernetes",
-                    "name": "devsecops_kube",
-                    "working_directory": "solutions",
-                    "compliance": {},
-                    "architecture": {},
-                    "configuration": [
-                        {
-                            "key": "ibmcloud_api_key",
-                            "type": "password",
-                            "description": "API key used to create the toolchain.",
-                            "required": true
-                        },
-                        {
-                            "key": "toolchain_name",
-                            "type": "string",
-                            "default_value": "DevSecOps CD Toolchain - Terraform",
-                            "description": "Name of the CD Toolchain.",
-                            "required": true
-                        },
-                        {
-                            "key": "toolchain_region",
-                            "type": "string",
-                            "default_value": "us-south",
-                            "description": "The region identifier that will be used, by default, for all resource creation and service instance lookup. This can be overridden on a per resource/service basis.",
-                            "display_name": "Region",
-                            "required": true,
-                            "custom_config": {
-                                "type": "region",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment",
-                                "config_constraints": {
-                                    "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
-                                    "showKinds": [
-                                        "region",
-                                        "zone",
-                                        "dc",
-                                        "location"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "key": "toolchain_resource_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The resource group that will be used, by default, for all resource creation and service instance lookups. This can be overridden on a per resource/service basis.",
-                            "display_name": "Resource group",
-                            "required": true,
-                            "custom_config": {
-                                "type": "resource_group",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment",
-                                "config_constraints": {
-                                    "identifier": "rg_name"
-                                }
-                            }
-                        },
-                        {
-                            "key": "cluster_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the Kubernetes cluster where the application is deployed.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_properties",
-                            "type": "string",
-                            "default_value": "[\n    {\n      \"pipeline_id\": \"cd\",\n      \"properties\": [\n        {\n            \"name\": \"change-request-id\",\n            \"type\": \"text\",\n            \"value\": \"notAvailable\"\n        },\n        {\n            \"name\": \"cluster\",\n            \"type\": \"text\",\n            \"value\": \"mycluster\"\n        },\n        {\n            \"name\": \"cluster-namespace\",\n            \"type\": \"text\",\n            \"value\": \"prod\"\n        },\n        {\n            \"name\": \"cluster_region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"code-signing-certificate\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-bucket-name\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-endpoint\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"doi-environment\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"doi-ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"doi-toolchain-id\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n          \"name\": \"emergency-label\",\n          \"type\": \"text\",\n          \"value\": \"EMERGENCY\"\n        },\n        {\n            \"name\": \"event-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"force-redeploy\",\n            \"type\": \"single_select\",\n            \"value\": \"false\",\n            \"enum\": \"[false,true]\"\n        },\n        {\n          \"name\": \"git-token\",\n          \"type\": \"secure\",\n          \"value\": \"\"\n        },\n        {\n            \"name\": \"ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"merge-cra-sbom\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"peer-review-compliance\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"pipeline-config\",\n            \"type\": \"text\",\n            \"value\": \".pipeline-config.yaml\"\n          },\n          {\n            \"name\": \"pipeline-config-branch\",\n            \"type\": \"text\",\n            \"value\": \"\"\n          },\n        {\n            \"name\": \"pipeline-debug\",\n            \"type\": \"single_select\",\n            \"value\": \"0\",\n            \"enum\": \"[0,1]\"\n        },\n        {\n            \"name\": \"pre-prod-evidence-collection\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"satellite-cluster-group\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"slack-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"source-environment\",\n            \"type\": \"text\",\n            \"value\": \"master\"\n        },\n        {\n            \"name\": \"target-environment\",\n            \"type\": \"text\",\n            \"value\": \"prod\"\n        },\n        {\n            \"name\": \"target-environment-detail\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"target-environment-purpose\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"version\",\n            \"type\": \"text\",\n            \"value\": \"v1\"\n        }\n      ]\n    }\n  ]\n",
-                            "description": "Stringified JSON containing the properties. This takes precedence over the properties JSON.",
-                            "display_name": "JSON",
-                            "required": true,
-                            "custom_config": {
-                                "type": "json_editor",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment"
-                            }
-                        },
-                        {
-                            "key": "evidence_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "This is a template repository to clone compliance-evidence-locker for reference DevSecOps toolchain templates.",
-                            "required": true
-                        },
-                        {
-                            "key": "inventory_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "This is a template repository to clone compliance-inventory-locker for reference DevSecOps toolchain templates.",
-                            "required": true
-                        },
-                        {
-                            "key": "issues_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "This is a template repository to clone compliance-issues for reference DevSecOps toolchain templates.",
-                            "required": true
-                        },
-                        {
-                            "key": "enable_secrets_manager",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set `true` to enable a Secrets Manager tool integration. If this is enabled then the Secrets Manager instance details are required. See the `sm_` prefixed variables in the optional section. This can be configured using a CRN or using a combination of the Secrets Manager name, region and resource group. An IBMcloud api key is required for running the pipelines. It is recommended that a secrets provider is used for storing the secrets. For a CRN configuration use `pipeline_ibmcloud_api_key_secret_crn` for setting the CRN for the apikey. Alternatively use `pipeline_ibmcloud_api_key_secret_name` for setting the name of the apikey as set in Secrets Manager. This applies to the non CRN configuration of the Secrets tool. ",
-                            "required": true
-                        },
-                        {
-                            "key": "sm_instance_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The CRN of the Secrets Manager instance. If the CRN is provided, it will take precendence over the subsequent `sm_` variables. Secrets using a CRN can be set with the variables ending in `secret_crn`",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_location",
-                            "type": "string",
-                            "default_value": "us-south",
-                            "description": "IBM Cloud location/region containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
-                            "display_name": "Region",
-                            "required": false,
-                            "custom_config": {
-                                "type": "region",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment",
-                                "config_constraints": {
-                                    "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
-                                    "showKinds": [
-                                        "region",
-                                        "zone",
-                                        "dc",
-                                        "location"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "key": "sm_name",
-                            "type": "string",
-                            "default_value": "sm-compliance-secrets",
-                            "description": "Name of the Secrets Manager instance where the secrets are stored. Not required if using a Secrets Manager CRN instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_resource_group",
-                            "type": "string",
-                            "default_value": "Default",
-                            "description": "The resource group containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_secret_group",
-                            "type": "string",
-                            "default_value": "Default",
-                            "description": "Group in Secrets Manager for organizing/grouping secrets.",
-                            "required": false
-                        },
-                        {
-                            "key": "add_pipeline_definitions",
-                            "type": "string",
-                            "default_value": "true",
-                            "description": "Set to `true` to add pipeline definitions.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_dashboard_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Type the URL that you want to navigate to when you click the Artifactory integration tile.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_integration_name",
-                            "type": "string",
-                            "default_value": "artifactory-dockerconfigjson",
-                            "description": "The name of the Artifactory tool integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_repo_name",
-                            "type": "string",
-                            "default_value": "wcp-compliance-automation-team-docker-local",
-                            "description": "Type the name of your Artifactory repository where your docker images are located.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Type the URL for your Artifactory release repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Artifactory secret.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_token_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Artifactory token secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_token_secret_name",
-                            "type": "string",
-                            "default_value": "artifactory-token",
-                            "description": "Name of the artifactory token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_user",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Type the User ID or email for your Artifactory repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "authorization_policy_creation",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set to disabled if you do not want this policy auto created.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_existing_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The URL for an existing Change Management repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for change management repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Choose the default git provider for change management repo",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Change Managemenrt repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Change Management repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_repo_clone_from_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Override the default management repo , which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
-                            "required": false
-                        },
-                        {
-                            "key": "cluster_namespace",
-                            "type": "string",
-                            "default_value": "default",
-                            "description": "Namespace of the Kubernetes cluster where the application is deployed.",
-                            "required": false
-                        },
-                        {
-                            "key": "cluster_region",
-                            "type": "string",
-                            "default_value": "ibm:yp:us-south",
-                            "description": "Region of the Kubernetes cluster where the application is deployed.",
-                            "required": false
-                        },
-                        {
-                            "key": "code_signing_cert_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this variable with the name of the secret containing the GPG public key from the Secrets Provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_existing_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The URL of an existing compliance pipelines repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for compliance pipeline repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Choose the default git provider for change management repo",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Compliance Pipeline repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Compliance Pipeline repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "URL of pipeline repo template to be cloned.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_source_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The URL of a compliance pipelines repository to clone.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Cloud Object Storage apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the COS API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the IBM Cloud Storage api-key secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_bucket_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "COS bucket name.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_dashboard_url",
-                            "type": "string",
-                            "default_value": "https://cloud.ibm.com/objectstorage",
-                            "description": "The dashboard URL for the COS toolcard.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_description",
-                            "type": "string",
-                            "default_value": "Cloud Object Storage to store evidences within DevSecOps Pipelines",
-                            "description": "The COS description on the tool card.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_documentation_url",
-                            "type": "string",
-                            "default_value": "https://cloud.ibm.com/objectstorage",
-                            "description": "The documentation URL that appears on the tool card.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_endpoint",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "COS endpoint name.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_integration_name",
-                            "type": "string",
-                            "default_value": "Evidence Store",
-                            "description": "The name of the COS integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "create_git_triggers",
-                            "type": "string",
-                            "default_value": "true",
-                            "description": "Set to `true` to create the default Git triggers associated with the compliance repos and sample app.",
-                            "required": false
-                        },
-                        {
-                            "key": "create_triggers",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to create all the default triggers.",
-                            "required": false
-                        },
-                        {
-                            "key": "default_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Choose the default git provider for app repo",
-                            "required": false
-                        },
-                        {
-                            "key": "default_locked_properties",
-                            "type": "array",
-                            "default_value": "[\"allow_test_servicenow\", \"app-concurrency\", \"app-deployment-timeout\", \"app-max-scale\", \"app-min-scale\", \"app-port\", \"app-visibility\", \"artifact-signature-verification\", \"change-management-repo\", \"cluster\", \"cluster-namespace\", \"cluster-region\", \"code-engine-binding-resource-group\", \"code-engine-deployment-type\", \"code-engine-project\", \"code-engine-region\", \"code-engine-resource-group\", \"code-signing-certificate\", \"compliance-baseimage\", \"cos-api-key\", \"cos-bucket-name\", \"cos-endpoint\", \"cpu\", \"cra-bom-generate\", \"cra-deploy-analysis\", \"cra-vulnerability-scan\", \"doi-environment\", \"doi-ibmcloud-api-key\", \"doi-toolchain-id\", \"emergency-label\", \"env-from-configmaps\", \"env-from-secrets\", \"ephemeral-storage\", \"event-notifications\", \"evidence-repo\", \"git-token\", \"ibmcloud-api\", \"ibmcloud-api-key\", \"incident-repo\", \"inventory-repo\", \"job-instances\", \"job-maxexecutiontime\", \"job-retrylimit\", \"memory\", \"pipeline-config\", \"pipeline-config-branch\", \"pipeline-config-repo\", \"pnp-ibmcloud-api\", \"pnp-ibmcloud-api-key\", \"pre-prod-evidence-collection\", \"remove-unspecified-references-to-configuration-resources\", \"service-bindings\", \"servicenow-api-base-url\", \"servicenow-crn-mask\", \"slack-notifications\", \"version\"]",
-                            "description": "List of default locked properties",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for deployment repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_from_branch",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Used when deployment_repo_clone_from_url is provided, the default branch that will be used by the CD build, usually either main or master.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_from_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Override the default sample app by providing your own sample deployment url, which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_to_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_to_git_provider",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_branch",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Used when deployment_repo_existing_url is provided, the default branch that will be used by the CD build, usually either main or master.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Override to bring your own existing deployment repository URL, which will be used directly instead of cloning the default deployment sample.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Deployment repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Deployment repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_source_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Url of deployment repo template",
-                            "required": false
-                        },
-                        {
-                            "key": "devsecops_flavor",
-                            "type": "string",
-                            "default_value": "kube",
-                            "description": "The deployment target, 'kube', 'code-engine' or 'zos'.",
-                            "required": false
-                        },
-                        {
-                            "key": "doi_toolchain_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "DevOps Insights Toolchain ID to link to.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_artifactory",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set true to enable artifacory for devsecops.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_change_management_repo",
-                            "type": "string",
-                            "default_value": "true",
-                            "description": "Set to `true` to enable the Change Management Repo integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_insights",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable the DevOps Insights integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_key_protect",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to enable Key Protect Integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_pipeline_git_token",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Enable to add `git-token` to the pipeline properties.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_pipeline_notifications",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "When enabled, pipeline run events will be sent to the Event Notifications and Slack integrations in the enclosing toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_privateworker",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set true to enable private worker for the CD toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_slack",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to true to create the integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "event_notifications_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The CRN for the Event Notifications instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "event_notifications_tool_name",
-                            "type": "string",
-                            "default_value": "Event Notifications",
-                            "description": "The name of the Event Notifications integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for evidence repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for evidence repo",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Evidence repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Evidence repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for inventory repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for inventory repo",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Inventory repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Inventory repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for issues repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for issue repo ",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Issues repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Issues repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_integration_name",
-                            "type": "string",
-                            "default_value": "kp-compliance-secrets",
-                            "description": "The name of the Key Protect integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_location",
-                            "type": "string",
-                            "default_value": "us-south",
-                            "description": "IBM Cloud location/region containing the Key Protect instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_name",
-                            "type": "string",
-                            "default_value": "kp-compliance-secrets",
-                            "description": "Name of the Key Protect instance where the secrets are stored.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_resource_group",
-                            "type": "string",
-                            "default_value": "Default",
-                            "description": "The resource group containing the Key Protect instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "link_to_doi_toolchain",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Enable a link to a DevOpsInsights instance in another toolchain, true or false.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_branch",
-                            "type": "string",
-                            "default_value": "open-v10",
-                            "description": "The branch within pipeline definitions repository for Compliance CD Toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for pipeline config repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_branch",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify the branch containing the custom pipeline-config.yaml file.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_clone_from_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify a repository to clone that contains a custom pipeline-config.yaml file.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_existing_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify a repository containing a custom pipeline-config.yaml file.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for pipeline repo config",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Config repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Pipeline Config repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_doi_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the DOI apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_doi_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the pipeline DOI api key. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_doi_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the Cloud API key secret in the secret provider to access the toolchain containing the Devops Insights instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_git_tag",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The GIT tag within the pipeline definitions repository for Compliance CD Toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_ibmcloud_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the pipeline apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_ibmcloud_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the pipeline ibmcloud API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_ibmcloud_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "ibmcloud-api-key",
-                            "description": "Name of the Cloud API key secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_properties_filepath",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The path to the file containing the property JSON. If this is not set, it will by default read the `properties.json` file at the root of the module.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_name",
-                            "type": "string",
-                            "default_value": "private-worker-tool-01",
-                            "description": "The name of the private worker integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_credentials_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Private Worker apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_credentials_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Private Worker secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_credentials_secret_name",
-                            "type": "string",
-                            "default_value": "private-worker-service-api",
-                            "description": "Name of the privateworker secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "region",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "IBM Cloud region used to prefix the `prod_latest` inventory repo branch.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The auth type for the repo `oauth` or 'pat` (personal access token). Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The Git ID for the compliance repositories.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_provider",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The Git provider type.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_token_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The CRN of the  Git token secret in the secret provider. Specifying a CRN for the Git Token automatically sets the authentication type to `pat`.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the Git token secret in the secret provider. Specifying a secret name for the Git Token automatically sets the authentication type to `pat`.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify the Git user or group for your application. This must be set if the repository authentication type is `pat` (personal access token).",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The integration owner of the repository. Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "repositories_prefix",
-                            "type": "string",
-                            "default_value": "compliance",
-                            "description": "Prefix name for the cloned compliance repos.",
-                            "required": false
-                        },
-                        {
-                            "key": "repository_properties",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Stringified JSON containing the repositories and triggers. This takes precedence over the repositories JSON.",
-                            "required": false
-                        },
-                        {
-                            "key": "repository_properties_filepath",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The path to the file containing the repository and triggers JSON. If this is not set, it will by default read the `repositories.json` file at the root of the module.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_attachment_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "An attachment ID. An attachment is configured under a profile to define how a scan will be run. To find the attachment ID, in the browser, in the attachments list, click on the attachment link, and a panel appears with a button to copy the attachment ID. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_enable_scc",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Enable the SCC integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_instance_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The Security and Compliance Center service instance CRN (Cloud Resource Name). This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled. The value must match the regular expression.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_integration_name",
-                            "type": "string",
-                            "default_value": "Devsecops Scope",
-                            "description": "The name of the SCC integration name.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_profile_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of a Security and Compliance Center profile. Use the `IBM Cloud Framework for Financial Services` profile, which contains the DevSecOps Toolchain rules. Or use a user-authored customized profile that has been configured to contain those rules. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_profile_version",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The version of a Security and Compliance Center profile, in SemVer format, like `0.0.0`. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_scc_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the SCC apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_scc_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Security and Compliance tool secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_scc_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "scc-api-key",
-                            "description": "The Security and Compliance Center api-key secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_use_profile_attachment",
-                            "type": "string",
-                            "default_value": "disabled",
-                            "description": "Set to `enabled` to enable use profile with attachment, so that the scripts in the pipeline can interact with the Security and Compliance Center service. When enabled, other parameters become relevant; `scc_scc_api_key_secret_name`, `scc_instance_crn`, `scc_profile_name`, `scc_profile_version`, `scc_attachment_id`.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_channel_name",
-                            "type": "string",
-                            "default_value": "my-channel",
-                            "description": "The Slack channel that notifications will be posted to.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_integration_name",
-                            "type": "string",
-                            "default_value": "slack-compliance",
-                            "description": "The name of the Slack integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_pipeline_fail",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate pipeline failed notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_pipeline_start",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate pipeline start notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_pipeline_success",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate pipeline succeeded notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_team_name",
-                            "type": "string",
-                            "default_value": "my-team",
-                            "description": "The Slack team name, which is the word or phrase before .slack.com in the team URL.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_toolchain_bind",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate tool added to toolchain notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_toolchain_unbind",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate tool removed from toolchain notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_webhook_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Slack webhook secret.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_webhook_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Slack webhook secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_webhook_secret_name",
-                            "type": "string",
-                            "default_value": "slack-webhook",
-                            "description": "Name of the webhook secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_integration_name",
-                            "type": "string",
-                            "default_value": "sm-compliance-secrets",
-                            "description": "The name of the Secrets Manager integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "toolchain_description",
-                            "type": "string",
-                            "default_value": "Toolchain created with Terraform template for DevSecOps CD Best Practices",
-                            "description": "Description for the CD oolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "toolchain_resource_region_override",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "IBM Cloud region for the created resources. If not set resources will be created in the region set in `toolchain_region`.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_enable",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable the CD pipeline Git trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_name",
-                            "type": "string",
-                            "default_value": "Git CD Trigger",
-                            "description": "The name of the CD pipeline GIT trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_branch",
-                            "type": "string",
-                            "default_value": "prod",
-                            "description": "Branch for Git promotion validation listener.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_enable",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Enable Git promotion validation for Git promotion listener.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_listener",
-                            "type": "string",
-                            "default_value": "promotion-validation-listener-gitlab",
-                            "description": "Select a Tekton EventListener to use when Git promotion validation listener trigger is fired.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_validation_name",
-                            "type": "string",
-                            "default_value": "Git Promotion Validation Trigger",
-                            "description": "Name of Git Promotion Validation Trigger",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_enable",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable the CD pipeline Manual trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_name",
-                            "type": "string",
-                            "default_value": "Manual CD Trigger",
-                            "description": "The name of the CD pipeline Manual trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_promotion_enable",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable the CD pipeline Manual Promotion trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_promotion_name",
-                            "type": "string",
-                            "default_value": "Manual Promotion Trigger",
-                            "description": "The name of the CD pipeline Manual Promotion trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_timed_cron_schedule",
-                            "type": "string",
-                            "default_value": "0 4 * * *",
-                            "description": "Only needed for timed triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_timed_enable",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable the CD pipeline Timed trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_timed_name",
-                            "type": "string",
-                            "default_value": "Git CD Timed Trigger",
-                            "description": "The name of the CD pipeline Timed trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "worker_id",
-                            "type": "string",
-                            "default_value": "public",
-                            "description": "The identifier for the Managed Pipeline worker.",
-                            "required": false
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "key": "cd_pipeline_id",
-                            "description": "The CD pipeline ID."
-                        },
-                        {
-                            "key": "change_management_repo",
-                            "description": "The Change Management repository."
-                        },
-                        {
-                            "key": "change_management_repo_git_id",
-                            "description": "The issues repository Git ID"
-                        },
-                        {
-                            "key": "change_management_repo_git_provider",
-                            "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "change_management_repo_url",
-                            "description": "The change management repository instance URL."
-                        },
-                        {
-                            "key": "deployment_repo",
-                            "description": "The Deployment repo."
-                        },
-                        {
-                            "key": "deployment_repo_git_id",
-                            "description": "The deployment repository Git ID"
-                        },
-                        {
-                            "key": "deployment_repo_git_provider",
-                            "description": "The deployment repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "deployment_repo_url",
-                            "description": "The deployment repo URL."
-                        },
-                        {
-                            "key": "evidence_repo",
-                            "description": "The Evidence repo."
-                        },
-                        {
-                            "key": "evidence_repo_git_id",
-                            "description": "The evidence repository Git ID"
-                        },
-                        {
-                            "key": "evidence_repo_git_provider",
-                            "description": "The evidence repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "evidence_repo_url",
-                            "description": "The evidence repository instance URL, where evidence of the builds and scans are stored, ready for any compliance audit."
-                        },
-                        {
-                            "key": "inventory_repo",
-                            "description": "The Inventory repo."
-                        },
-                        {
-                            "key": "inventory_repo_git_id",
-                            "description": "The inventory repository Git ID"
-                        },
-                        {
-                            "key": "inventory_repo_git_provider",
-                            "description": "The inventory repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "inventory_repo_url",
-                            "description": "The inventory repository instance URL, with details of which artifact has been built and will be deployed."
-                        },
-                        {
-                            "key": "issues_repo",
-                            "description": "The Issues repo."
-                        },
-                        {
-                            "key": "issues_repo_git_id",
-                            "description": "The issues repository Git ID"
-                        },
-                        {
-                            "key": "issues_repo_git_provider",
-                            "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "issues_repo_url",
-                            "description": "The incident issues repository instance URL, where issues are created when vulnerabilities and CVEs are detected."
-                        },
-                        {
-                            "key": "key_protect_instance_id",
-                            "description": "The Key Protect instance ID."
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_id",
-                            "description": "The compliance pipeline repository Git ID"
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_provider",
-                            "description": "The compliance pipeline repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "pipeline_config_repo_url",
-                            "description": "This repository URL contains the tekton definitions for compliance pipelines."
-                        },
-                        {
-                            "key": "pipeline_repo_url",
-                            "description": "This repository URL contains the tekton definitions for compliance pipelines."
-                        },
-                        {
-                            "key": "secrets_manager_instance_id",
-                            "description": "The Secrets Manager instance ID."
-                        },
-                        {
-                            "key": "secret_tool",
-                            "description": "The secret tool."
-                        },
-                        {
-                            "key": "secret_tool_v1",
-                            "description": "The legacy secret tool. Used as part of secret references to point to the secret tool integration. This is the legacy version of the secrets tool. The new version was updated to support using different secret groups with Secrests Manager. This only effects Secrets Manager. The net difference is that the legacy secret tool returns the tool name and the secret group name whereas the new tool returns only the tool name."
-                        },
-                        {
-                            "key": "toolchain_id",
-                            "description": "The CD toolchain ID."
-                        },
-                        {
-                            "key": "toolchain_url",
-                            "description": "The CD toolchain URL."
-                        }
-                    ],
-                    "install_type": "fullstack"
-                },
-                {
-                    "label": "Deploy to Code Engine",
-                    "name": "devsecops_ce",
-                    "working_directory": "solutions",
-                    "compliance": {},
-                    "architecture": {},
-                    "configuration": [
-                        {
-                            "key": "ibmcloud_api_key",
-                            "type": "password",
-                            "description": "API key used to create the toolchain.",
-                            "required": true
-                        },
-                        {
-                            "key": "toolchain_name",
-                            "type": "string",
-                            "default_value": "DevSecOps CD Toolchain - Terraform",
-                            "description": "Name of the CD Toolchain.",
-                            "required": true
-                        },
-                        {
-                            "key": "toolchain_region",
-                            "type": "string",
-                            "default_value": "us-south",
-                            "description": "The region identifier that will be used, by default, for all resource creation and service instance lookup. This can be overridden on a per resource/service basis.",
-                            "display_name": "Region",
-                            "required": true,
-                            "custom_config": {
-                                "type": "region",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment",
-                                "config_constraints": {
-                                    "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
-                                    "showKinds": [
-                                        "region",
-                                        "zone",
-                                        "dc",
-                                        "location"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "key": "toolchain_resource_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The resource group that will be used, by default, for all resource creation and service instance lookups. This can be overridden on a per resource/service basis.",
-                            "display_name": "Resource group",
-                            "required": true,
-                            "custom_config": {
-                                "type": "resource_group",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment",
-                                "config_constraints": {
-                                    "identifier": "rg_name"
-                                }
-                            }
-                        },
-                        {
-                            "key": "code_engine_project",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the Code Engine project to use. Created if it does not exist.",
-                            "required": true
-                        },
-                        {
-                            "key": "pipeline_properties",
-                            "type": "string",
-                            "default_value": "[\n    {\n      \"pipeline_id\": \"cd\",\n      \"properties\": [\n        {\n            \"name\": \"app-concurrency\",\n            \"type\": \"text\",\n            \"value\": \"100\"\n        },\n        {\n            \"name\": \"app-deployment-timeout\",\n            \"type\": \"text\",\n            \"value\": \"300\"\n        },\n        {\n            \"name\": \"app-max-scale\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"app-min-scale\",\n            \"type\": \"text\",\n            \"value\": \"0\"\n        },\n        {\n            \"name\": \"app-port\",\n            \"type\": \"text\",\n            \"value\": \"8080\"\n        },\n        {\n            \"name\": \"app-visibility\",\n            \"type\": \"text\",\n            \"value\": \"public\"\n        },\n        {\n            \"name\": \"change-request-id\",\n            \"type\": \"text\",\n            \"value\": \"notAvailable\"\n        },\n        {\n            \"name\": \"code-engine-binding-resource-group\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"code-engine-deployment-type\",\n            \"type\": \"text\",\n            \"value\": \"application\"\n        },\n        {\n            \"name\": \"code-engine-project\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"code-engine-region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"code-engine-resource-group\",\n            \"type\": \"text\",\n            \"value\": \"Default\"\n        },\n        {\n            \"name\": \"code-signing-certificate\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-bucket-name\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-endpoint\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cpu\",\n            \"type\": \"text\",\n            \"value\": \"0.25\"\n        },\n        {\n            \"name\": \"doi-environment\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"doi-ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"doi-toolchain-id\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n          \"name\": \"emergency-label\",\n          \"type\": \"text\",\n          \"value\": \"EMERGENCY\"\n        },\n        {\n            \"name\": \"env-from-configmaps\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"env-from-secrets\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"ephemeral-storage\",\n            \"type\": \"text\",\n            \"value\": \"0.4G\"\n        },\n        {\n            \"name\": \"event-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"force-redeploy\",\n            \"type\": \"single_select\",\n            \"value\": \"false\",\n            \"enum\": \"[false,true]\"\n        },\n        {\n          \"name\": \"git-token\",\n          \"type\": \"secure\",\n          \"value\": \"\"\n        },\n        {\n            \"name\": \"ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"job-instances\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"job-maxexecutiontime\",\n            \"type\": \"text\",\n            \"value\": \"7200\"\n        },\n        {\n            \"name\": \"job-retrylimit\",\n            \"type\": \"text\",\n            \"value\": \"3\"\n        },\n        {\n            \"name\": \"memory\",\n            \"type\": \"text\",\n            \"value\": \"0.5G\"\n        },\n        {\n            \"name\": \"merge-cra-sbom\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"peer-review-collection\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"peer-review-compliance\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"pipeline-config\",\n            \"type\": \"text\",\n            \"value\": \".pipeline-config.yaml\"\n          },\n          {\n            \"name\": \"pipeline-config-branch\",\n            \"type\": \"text\",\n            \"value\": \"\"\n          },\n        {\n            \"name\": \"pipeline-debug\",\n            \"type\": \"single_select\",\n            \"value\": \"0\",\n            \"enum\": \"[0,1]\"\n        },\n        {\n            \"name\": \"pre-prod-evidence-collection\",\n            \"type\": \"text\",\n            \"value\": \"0\"\n        },\n        {\n            \"name\": \"region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"remove-unspecified-references-to-configuration-resources\",\n            \"type\": \"text\",\n            \"value\": \"false\"\n        },\n        {\n            \"name\": \"service-bindings\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"slack-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"source-environment\",\n            \"type\": \"text\",\n            \"value\": \"master\"\n        },\n        {\n            \"name\": \"target-environment\",\n            \"type\": \"text\",\n            \"value\": \"prod\"\n        },\n        {\n            \"name\": \"target-environment-detail\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"target-environment-purpose\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"version\",\n            \"type\": \"text\",\n            \"value\": \"v1\"\n        }\n      ]\n    }\n  ]\n",
-                            "description": "Stringified JSON containing the properties. This takes precedence over the properties JSON.",
-                            "display_name": "JSON",
-                            "required": true,
-                            "custom_config": {
-                                "type": "json_editor",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment"
-                            }
-                        },
-                        {
-                            "key": "evidence_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "This is a template repository to clone compliance-evidence-locker for reference DevSecOps toolchain templates.",
-                            "required": true
-                        },
-                        {
-                            "key": "inventory_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "This is a template repository to clone compliance-inventory-locker for reference DevSecOps toolchain templates.",
-                            "required": true
-                        },
-                        {
-                            "key": "issues_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "This is a template repository to clone compliance-issues for reference DevSecOps toolchain templates.",
-                            "required": true
-                        },
-                        {
-                            "key": "enable_secrets_manager",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set `true` to enable a Secrets Manager tool integration. If this is enabled then the Secrets Manager instance details are required. See the `sm_` prefixed variables in the optional section. This can be configured using a CRN or using a combination of the Secrets Manager name, region and resource group. An IBMcloud api key is required for running the pipelines. It is recommended that a secrets provider is used for storing the secrets. For a CRN configuration use `pipeline_ibmcloud_api_key_secret_crn` for setting the CRN for the apikey. Alternatively use `pipeline_ibmcloud_api_key_secret_name` for setting the name of the apikey as set in Secrets Manager. This applies to the non CRN configuration of the Secrets tool. ",
-                            "required": true
-                        },
-                        {
-                            "key": "sm_instance_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The CRN of the Secrets Manager instance. If the CRN is provided, it will take precendence over the subsequent `sm_` variables. Secrets using a CRN can be set with the variables ending in `secret_crn`",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_location",
-                            "type": "string",
-                            "default_value": "us-south",
-                            "description": "IBM Cloud location/region containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
-                            "display_name": "Region",
-                            "required": false,
-                            "custom_config": {
-                                "type": "region",
-                                "grouping": "deployment",
-                                "original_grouping": "deployment",
-                                "config_constraints": {
-                                    "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
-                                    "showKinds": [
-                                        "region",
-                                        "zone",
-                                        "dc",
-                                        "location"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "key": "sm_name",
-                            "type": "string",
-                            "default_value": "sm-compliance-secrets",
-                            "description": "Name of the Secrets Manager instance where the secrets are stored. Not required if using a Secrets Manager CRN instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_resource_group",
-                            "type": "string",
-                            "default_value": "Default",
-                            "description": "The resource group containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_secret_group",
-                            "type": "string",
-                            "default_value": "Default",
-                            "description": "Group in Secrets Manager for organizing/grouping secrets.",
-                            "required": false
-                        },
-                        {
-                            "key": "add_pipeline_definitions",
-                            "type": "string",
-                            "default_value": "true",
-                            "description": "Set to `true` to add pipeline definitions.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_dashboard_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Type the URL that you want to navigate to when you click the Artifactory integration tile.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_integration_name",
-                            "type": "string",
-                            "default_value": "artifactory-dockerconfigjson",
-                            "description": "The name of the Artifactory tool integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_repo_name",
-                            "type": "string",
-                            "default_value": "wcp-compliance-automation-team-docker-local",
-                            "description": "Type the name of your Artifactory repository where your docker images are located.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Type the URL for your Artifactory release repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Artifactory secret.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_token_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Artifactory token secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_token_secret_name",
-                            "type": "string",
-                            "default_value": "artifactory-token",
-                            "description": "Name of the artifactory token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "artifactory_user",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Type the User ID or email for your Artifactory repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "authorization_policy_creation",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set to disabled if you do not want this policy auto created.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_existing_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The URL for an existing Change Management repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for change management repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Choose the default git provider for change management repo",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Change Managemenrt repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Change Management repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_management_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "change_repo_clone_from_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Override the default management repo , which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
-                            "required": false
-                        },
-                        {
-                            "key": "cluster_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the Kubernetes cluster where the application is deployed.",
-                            "required": false
-                        },
-                        {
-                            "key": "cluster_namespace",
-                            "type": "string",
-                            "default_value": "default",
-                            "description": "Namespace of the Kubernetes cluster where the application is deployed.",
-                            "required": false
-                        },
-                        {
-                            "key": "cluster_region",
-                            "type": "string",
-                            "default_value": "ibm:yp:us-south",
-                            "description": "Region of the Kubernetes cluster where the application is deployed.",
-                            "required": false
-                        },
-                        {
-                            "key": "code_engine_region",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The region to create/lookup for the Code Engine project.",
-                            "required": false
-                        },
-                        {
-                            "key": "code_engine_resource_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The resource group of the Code Engine project.",
-                            "required": false
-                        },
-                        {
-                            "key": "code_signing_cert_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this variable with the name of the secret containing the GPG public key from the Secrets Provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_existing_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The URL of an existing compliance pipelines repository.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for compliance pipeline repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Choose the default git provider for change management repo",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Compliance Pipeline repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Compliance Pipeline repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "URL of pipeline repo template to be cloned.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipeline_source_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The URL of a compliance pipelines repository to clone.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "compliance_pipelines_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Cloud Object Storage apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the COS API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the IBM Cloud Storage api-key secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_bucket_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "COS bucket name.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_dashboard_url",
-                            "type": "string",
-                            "default_value": "https://cloud.ibm.com/objectstorage",
-                            "description": "The dashboard URL for the COS toolcard.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_description",
-                            "type": "string",
-                            "default_value": "Cloud Object Storage to store evidences within DevSecOps Pipelines",
-                            "description": "The COS description on the tool card.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_documentation_url",
-                            "type": "string",
-                            "default_value": "https://cloud.ibm.com/objectstorage",
-                            "description": "The documentation URL that appears on the tool card.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_endpoint",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "COS endpoint name.",
-                            "required": false
-                        },
-                        {
-                            "key": "cos_integration_name",
-                            "type": "string",
-                            "default_value": "Evidence Store",
-                            "description": "The name of the COS integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "create_git_triggers",
-                            "type": "string",
-                            "default_value": "true",
-                            "description": "Set to `true` to create the default Git triggers associated with the compliance repos and sample app.",
-                            "required": false
-                        },
-                        {
-                            "key": "create_triggers",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to create all the default triggers.",
-                            "required": false
-                        },
-                        {
-                            "key": "default_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Choose the default git provider for app repo",
-                            "required": false
-                        },
-                        {
-                            "key": "default_locked_properties",
-                            "type": "array",
-                            "default_value": "[\"allow_test_servicenow\", \"app-concurrency\", \"app-deployment-timeout\", \"app-max-scale\", \"app-min-scale\", \"app-port\", \"app-visibility\", \"artifact-signature-verification\", \"change-management-repo\", \"cluster\", \"cluster-namespace\", \"cluster-region\", \"code-engine-binding-resource-group\", \"code-engine-deployment-type\", \"code-engine-project\", \"code-engine-region\", \"code-engine-resource-group\", \"code-signing-certificate\", \"compliance-baseimage\", \"cos-api-key\", \"cos-bucket-name\", \"cos-endpoint\", \"cpu\", \"cra-bom-generate\", \"cra-deploy-analysis\", \"cra-vulnerability-scan\", \"doi-environment\", \"doi-ibmcloud-api-key\", \"doi-toolchain-id\", \"emergency-label\", \"env-from-configmaps\", \"env-from-secrets\", \"ephemeral-storage\", \"event-notifications\", \"evidence-repo\", \"git-token\", \"ibmcloud-api\", \"ibmcloud-api-key\", \"incident-repo\", \"inventory-repo\", \"job-instances\", \"job-maxexecutiontime\", \"job-retrylimit\", \"memory\", \"pipeline-config\", \"pipeline-config-branch\", \"pipeline-config-repo\", \"pnp-ibmcloud-api\", \"pnp-ibmcloud-api-key\", \"pre-prod-evidence-collection\", \"remove-unspecified-references-to-configuration-resources\", \"service-bindings\", \"servicenow-api-base-url\", \"servicenow-crn-mask\", \"slack-notifications\", \"version\"]",
-                            "description": "List of default locked properties",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for deployment repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_from_branch",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Used when deployment_repo_clone_from_url is provided, the default branch that will be used by the CD build, usually either main or master.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_from_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Override the default sample app by providing your own sample deployment url, which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_to_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_clone_to_git_provider",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_branch",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Used when deployment_repo_existing_url is provided, the default branch that will be used by the CD build, usually either main or master.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_existing_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Override to bring your own existing deployment repository URL, which will be used directly instead of cloning the default deployment sample.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Deployment repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Deployment repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "deployment_source_repo_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Url of deployment repo template",
-                            "required": false
-                        },
-                        {
-                            "key": "devsecops_flavor",
-                            "type": "string",
-                            "default_value": "kube",
-                            "description": "The deployment target, 'kube', 'code-engine' or 'zos'.",
-                            "required": false
-                        },
-                        {
-                            "key": "doi_toolchain_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "DevOps Insights Toolchain ID to link to.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_artifactory",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set true to enable artifacory for devsecops.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_change_management_repo",
-                            "type": "string",
-                            "default_value": "true",
-                            "description": "Set to `true` to enable the Change Management Repo integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_insights",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable the DevOps Insights integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_key_protect",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to enable Key Protect Integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_pipeline_git_token",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Enable to add `git-token` to the pipeline properties.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_pipeline_notifications",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "When enabled, pipeline run events will be sent to the Event Notifications and Slack integrations in the enclosing toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_privateworker",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set true to enable private worker for the CD toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "enable_slack",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to true to create the integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "event_notifications_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The CRN for the Event Notifications instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "event_notifications_tool_name",
-                            "type": "string",
-                            "default_value": "Event Notifications",
-                            "description": "The name of the Event Notifications integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for evidence repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for evidence repo",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Evidence repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Evidence repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "evidence_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for inventory repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for inventory repo",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Inventory repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Inventory repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "inventory_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for issues repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for issue repo ",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Issues repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Issues repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "issues_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_integration_name",
-                            "type": "string",
-                            "default_value": "kp-compliance-secrets",
-                            "description": "The name of the Key Protect integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_location",
-                            "type": "string",
-                            "default_value": "us-south",
-                            "description": "IBM Cloud location/region containing the Key Protect instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_name",
-                            "type": "string",
-                            "default_value": "kp-compliance-secrets",
-                            "description": "Name of the Key Protect instance where the secrets are stored.",
-                            "required": false
-                        },
-                        {
-                            "key": "kp_resource_group",
-                            "type": "string",
-                            "default_value": "Default",
-                            "description": "The resource group containing the Key Protect instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "link_to_doi_toolchain",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Enable a link to a DevOpsInsights instance in another toolchain, true or false.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_branch",
-                            "type": "string",
-                            "default_value": "open-v10",
-                            "description": "The branch within pipeline definitions repository for Compliance CD Toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify Git user/group for pipeline config repo.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_branch",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify the branch containing the custom pipeline-config.yaml file.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_clone_from_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify a repository to clone that contains a custom pipeline-config.yaml file.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_existing_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify a repository containing a custom pipeline-config.yaml file.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_provider",
-                            "type": "string",
-                            "default_value": "hostedgit",
-                            "description": "Git provider for pipeline repo config",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_token_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Config repository Git Token.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "git-token",
-                            "description": "Name of the Git token secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_initialization_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of the integration owner.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_is_private_repo",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to make repository private.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_issues_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable issues.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The repository name.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Pipeline Config repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_config_repo_traceability_enabled",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable traceability.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_doi_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the DOI apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_doi_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the pipeline DOI api key. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_doi_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the Cloud API key secret in the secret provider to access the toolchain containing the Devops Insights instance.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_git_tag",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The GIT tag within the pipeline definitions repository for Compliance CD Toolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_ibmcloud_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the pipeline apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_ibmcloud_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the pipeline ibmcloud API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_ibmcloud_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "ibmcloud-api-key",
-                            "description": "Name of the Cloud API key secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "pipeline_properties_filepath",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The path to the file containing the property JSON. If this is not set, it will by default read the `properties.json` file at the root of the module.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_name",
-                            "type": "string",
-                            "default_value": "private-worker-tool-01",
-                            "description": "The name of the private worker integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_credentials_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Private Worker apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_credentials_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Private Worker secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "privateworker_credentials_secret_name",
-                            "type": "string",
-                            "default_value": "private-worker-service-api",
-                            "description": "Name of the privateworker secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "region",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "IBM Cloud region used to prefix the `prod_latest` inventory repo branch.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_auth_type",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The auth type for the repo `oauth` or 'pat` (personal access token). Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_blind_connection",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The Git ID for the compliance repositories.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_provider",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The Git provider type.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_token_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The CRN of the  Git token secret in the secret provider. Specifying a CRN for the Git Token automatically sets the authentication type to `pat`.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_git_token_secret_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Name of the Git token secret in the secret provider. Specifying a secret name for the Git Token automatically sets the authentication type to `pat`.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Specify the Git user or group for your application. This must be set if the repository authentication type is `pat` (personal access token).",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_integration_owner",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The integration owner of the repository. Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_root_url",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
-                            "required": false
-                        },
-                        {
-                            "key": "repo_title",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
-                            "required": false
-                        },
-                        {
-                            "key": "repositories_prefix",
-                            "type": "string",
-                            "default_value": "compliance",
-                            "description": "Prefix name for the cloned compliance repos.",
-                            "required": false
-                        },
-                        {
-                            "key": "repository_properties",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Stringified JSON containing the repositories and triggers. This takes precedence over the repositories JSON.",
-                            "required": false
-                        },
-                        {
-                            "key": "repository_properties_filepath",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The path to the file containing the repository and triggers JSON. If this is not set, it will by default read the `repositories.json` file at the root of the module.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_attachment_id",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "An attachment ID. An attachment is configured under a profile to define how a scan will be run. To find the attachment ID, in the browser, in the attachments list, click on the attachment link, and a panel appears with a button to copy the attachment ID. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_enable_scc",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Enable the SCC integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_instance_crn",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The Security and Compliance Center service instance CRN (Cloud Resource Name). This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled. The value must match the regular expression.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_integration_name",
-                            "type": "string",
-                            "default_value": "Devsecops Scope",
-                            "description": "The name of the SCC integration name.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_profile_name",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The name of a Security and Compliance Center profile. Use the `IBM Cloud Framework for Financial Services` profile, which contains the DevSecOps Toolchain rules. Or use a user-authored customized profile that has been configured to contain those rules. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_profile_version",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "The version of a Security and Compliance Center profile, in SemVer format, like `0.0.0`. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_scc_api_key_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the SCC apikey.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_scc_api_key_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Security and Compliance tool secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_scc_api_key_secret_name",
-                            "type": "string",
-                            "default_value": "scc-api-key",
-                            "description": "The Security and Compliance Center api-key secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "scc_use_profile_attachment",
-                            "type": "string",
-                            "default_value": "disabled",
-                            "description": "Set to `enabled` to enable use profile with attachment, so that the scripts in the pipeline can interact with the Security and Compliance Center service. When enabled, other parameters become relevant; `scc_scc_api_key_secret_name`, `scc_instance_crn`, `scc_profile_name`, `scc_profile_version`, `scc_attachment_id`.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_channel_name",
-                            "type": "string",
-                            "default_value": "my-channel",
-                            "description": "The Slack channel that notifications will be posted to.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_integration_name",
-                            "type": "string",
-                            "default_value": "slack-compliance",
-                            "description": "The name of the Slack integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_pipeline_fail",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate pipeline failed notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_pipeline_start",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate pipeline start notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_pipeline_success",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate pipeline succeeded notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_team_name",
-                            "type": "string",
-                            "default_value": "my-team",
-                            "description": "The Slack team name, which is the word or phrase before .slack.com in the team URL.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_toolchain_bind",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate tool added to toolchain notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_toolchain_unbind",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Generate tool removed from toolchain notifications.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_webhook_secret_crn",
-                            "type": "password",
-                            "description": "The CRN for the Slack webhook secret.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_webhook_secret_group",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "Secret group prefix for the Slack webhook secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
-                            "required": false
-                        },
-                        {
-                            "key": "slack_webhook_secret_name",
-                            "type": "string",
-                            "default_value": "slack-webhook",
-                            "description": "Name of the webhook secret in the secret provider.",
-                            "required": false
-                        },
-                        {
-                            "key": "sm_integration_name",
-                            "type": "string",
-                            "default_value": "sm-compliance-secrets",
-                            "description": "The name of the Secrets Manager integration.",
-                            "required": false
-                        },
-                        {
-                            "key": "toolchain_description",
-                            "type": "string",
-                            "default_value": "Toolchain created with Terraform template for DevSecOps CD Best Practices",
-                            "description": "Description for the CD oolchain.",
-                            "required": false
-                        },
-                        {
-                            "key": "toolchain_resource_region_override",
-                            "type": "string",
-                            "default_value": "",
-                            "description": "IBM Cloud region for the created resources. If not set resources will be created in the region set in `toolchain_region`.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_enable",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable the CD pipeline Git trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_name",
-                            "type": "string",
-                            "default_value": "Git CD Trigger",
-                            "description": "The name of the CD pipeline GIT trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_branch",
-                            "type": "string",
-                            "default_value": "prod",
-                            "description": "Branch for Git promotion validation listener.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_enable",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Enable Git promotion validation for Git promotion listener.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_listener",
-                            "type": "string",
-                            "default_value": "promotion-validation-listener-gitlab",
-                            "description": "Select a Tekton EventListener to use when Git promotion validation listener trigger is fired.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_git_promotion_validation_name",
-                            "type": "string",
-                            "default_value": "Git Promotion Validation Trigger",
-                            "description": "Name of Git Promotion Validation Trigger",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_enable",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable the CD pipeline Manual trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_name",
-                            "type": "string",
-                            "default_value": "Manual CD Trigger",
-                            "description": "The name of the CD pipeline Manual trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_promotion_enable",
-                            "type": "boolean",
-                            "default_value": true,
-                            "description": "Set to `true` to enable the CD pipeline Manual Promotion trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_manual_promotion_name",
-                            "type": "string",
-                            "default_value": "Manual Promotion Trigger",
-                            "description": "The name of the CD pipeline Manual Promotion trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_timed_cron_schedule",
-                            "type": "string",
-                            "default_value": "0 4 * * *",
-                            "description": "Only needed for timed triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_timed_enable",
-                            "type": "boolean",
-                            "default_value": false,
-                            "description": "Set to `true` to enable the CD pipeline Timed trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "trigger_timed_name",
-                            "type": "string",
-                            "default_value": "Git CD Timed Trigger",
-                            "description": "The name of the CD pipeline Timed trigger.",
-                            "required": false
-                        },
-                        {
-                            "key": "worker_id",
-                            "type": "string",
-                            "default_value": "public",
-                            "description": "The identifier for the Managed Pipeline worker.",
-                            "required": false
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "key": "cd_pipeline_id",
-                            "description": "The CD pipeline ID."
-                        },
-                        {
-                            "key": "change_management_repo",
-                            "description": "The Change Management repository."
-                        },
-                        {
-                            "key": "change_management_repo_git_id",
-                            "description": "The issues repository Git ID"
-                        },
-                        {
-                            "key": "change_management_repo_git_provider",
-                            "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "change_management_repo_url",
-                            "description": "The change management repository instance URL."
-                        },
-                        {
-                            "key": "deployment_repo",
-                            "description": "The Deployment repo."
-                        },
-                        {
-                            "key": "deployment_repo_git_id",
-                            "description": "The deployment repository Git ID"
-                        },
-                        {
-                            "key": "deployment_repo_git_provider",
-                            "description": "The deployment repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "deployment_repo_url",
-                            "description": "The deployment repo URL."
-                        },
-                        {
-                            "key": "evidence_repo",
-                            "description": "The Evidence repo."
-                        },
-                        {
-                            "key": "evidence_repo_git_id",
-                            "description": "The evidence repository Git ID"
-                        },
-                        {
-                            "key": "evidence_repo_git_provider",
-                            "description": "The evidence repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "evidence_repo_url",
-                            "description": "The evidence repository instance URL, where evidence of the builds and scans are stored, ready for any compliance audit."
-                        },
-                        {
-                            "key": "inventory_repo",
-                            "description": "The Inventory repo."
-                        },
-                        {
-                            "key": "inventory_repo_git_id",
-                            "description": "The inventory repository Git ID"
-                        },
-                        {
-                            "key": "inventory_repo_git_provider",
-                            "description": "The inventory repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "inventory_repo_url",
-                            "description": "The inventory repository instance URL, with details of which artifact has been built and will be deployed."
-                        },
-                        {
-                            "key": "issues_repo",
-                            "description": "The Issues repo."
-                        },
-                        {
-                            "key": "issues_repo_git_id",
-                            "description": "The issues repository Git ID"
-                        },
-                        {
-                            "key": "issues_repo_git_provider",
-                            "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "issues_repo_url",
-                            "description": "The incident issues repository instance URL, where issues are created when vulnerabilities and CVEs are detected."
-                        },
-                        {
-                            "key": "key_protect_instance_id",
-                            "description": "The Key Protect instance ID."
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_id",
-                            "description": "The compliance pipeline repository Git ID"
-                        },
-                        {
-                            "key": "pipeline_config_repo_git_provider",
-                            "description": "The compliance pipeline repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
-                        },
-                        {
-                            "key": "pipeline_config_repo_url",
-                            "description": "This repository URL contains the tekton definitions for compliance pipelines."
-                        },
-                        {
-                            "key": "pipeline_repo_url",
-                            "description": "This repository URL contains the tekton definitions for compliance pipelines."
-                        },
-                        {
-                            "key": "secrets_manager_instance_id",
-                            "description": "The Secrets Manager instance ID."
-                        },
-                        {
-                            "key": "secret_tool",
-                            "description": "The secret tool."
-                        },
-                        {
-                            "key": "secret_tool_v1",
-                            "description": "The legacy secret tool. Used as part of secret references to point to the secret tool integration. This is the legacy version of the secrets tool. The new version was updated to support using different secret groups with Secrests Manager. This only effects Secrets Manager. The net difference is that the legacy secret tool returns the tool name and the secret group name whereas the new tool returns only the tool name."
-                        },
-                        {
-                            "key": "toolchain_id",
-                            "description": "The CD toolchain ID."
-                        },
-                        {
-                            "key": "toolchain_url",
-                            "description": "The CD toolchain URL."
-                        }
-                    ],
-                    "install_type": "fullstack"
+          "label": "Deploy to Kubernetes",
+          "name": "devsecops_kube",
+          "working_directory": "solutions",
+          "compliance": {},
+          "architecture": {},
+          "configuration": [
+            {
+              "key": "ibmcloud_api_key",
+              "type": "password",
+              "description": "API key used to create the toolchain.",
+              "required": true
+            },
+            {
+              "key": "toolchain_name",
+              "type": "string",
+              "default_value": "DevSecOps CD Toolchain - Terraform",
+              "description": "Name of the CD Toolchain.",
+              "required": true
+            },
+            {
+              "key": "toolchain_region",
+              "type": "string",
+              "default_value": "us-south",
+              "description": "The region identifier that will be used, by default, for all resource creation and service instance lookup. This can be overridden on a per resource/service basis.",
+              "display_name": "Region",
+              "required": true,
+              "custom_config": {
+                "type": "region",
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "config_constraints": {
+                  "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
+                  "showKinds": [
+                    "region",
+                    "zone",
+                    "dc",
+                    "location"
+                  ]
                 }
-            ]
+              }
+            },
+            {
+              "key": "toolchain_resource_group",
+              "type": "string",
+              "default_value": "",
+              "description": "The resource group that will be used, by default, for all resource creation and service instance lookups. This can be overridden on a per resource/service basis.",
+              "display_name": "Resource group",
+              "required": true,
+              "custom_config": {
+                "type": "resource_group",
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "config_constraints": {
+                  "identifier": "rg_name"
+                }
+              }
+            },
+            {
+              "key": "cluster_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the Kubernetes cluster where the application is deployed.",
+              "required": false
+            },
+            {
+              "key": "pipeline_properties",
+              "type": "string",
+              "default_value": "[\n    {\n      \"pipeline_id\": \"cd\",\n      \"properties\": [\n        {\n            \"name\": \"change-request-id\",\n            \"type\": \"text\",\n            \"value\": \"notAvailable\"\n        },\n        {\n            \"name\": \"cluster\",\n            \"type\": \"text\",\n            \"value\": \"mycluster\"\n        },\n        {\n            \"name\": \"cluster-namespace\",\n            \"type\": \"text\",\n            \"value\": \"prod\"\n        },\n        {\n            \"name\": \"cluster_region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"code-signing-certificate\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-bucket-name\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-endpoint\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"doi-environment\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"doi-ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"doi-toolchain-id\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n          \"name\": \"emergency-label\",\n          \"type\": \"text\",\n          \"value\": \"EMERGENCY\"\n        },\n        {\n            \"name\": \"event-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"force-redeploy\",\n            \"type\": \"single_select\",\n            \"value\": \"false\",\n            \"enum\": \"[false,true]\"\n        },\n        {\n          \"name\": \"git-token\",\n          \"type\": \"secure\",\n          \"value\": \"\"\n        },\n        {\n            \"name\": \"ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"merge-cra-sbom\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"peer-review-compliance\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"pipeline-config\",\n            \"type\": \"text\",\n            \"value\": \".pipeline-config.yaml\"\n          },\n          {\n            \"name\": \"pipeline-config-branch\",\n            \"type\": \"text\",\n            \"value\": \"\"\n          },\n        {\n            \"name\": \"pipeline-debug\",\n            \"type\": \"single_select\",\n            \"value\": \"0\",\n            \"enum\": \"[0,1]\"\n        },\n        {\n            \"name\": \"pre-prod-evidence-collection\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"satellite-cluster-group\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"slack-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"source-environment\",\n            \"type\": \"text\",\n            \"value\": \"master\"\n        },\n        {\n            \"name\": \"target-environment\",\n            \"type\": \"text\",\n            \"value\": \"prod\"\n        },\n        {\n            \"name\": \"target-environment-detail\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"target-environment-purpose\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"version\",\n            \"type\": \"text\",\n            \"value\": \"v1\"\n        }\n      ]\n    }\n  ]\n",
+              "description": "Stringified JSON containing the properties. This takes precedence over the properties JSON.",
+              "display_name": "JSON",
+              "required": true,
+              "custom_config": {
+                "type": "json_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
+            },
+            {
+              "key": "evidence_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "This is a template repository to clone compliance-evidence-locker for reference DevSecOps toolchain templates.",
+              "required": true
+            },
+            {
+              "key": "inventory_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "This is a template repository to clone compliance-inventory-locker for reference DevSecOps toolchain templates.",
+              "required": true
+            },
+            {
+              "key": "issues_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "This is a template repository to clone compliance-issues for reference DevSecOps toolchain templates.",
+              "required": true
+            },
+            {
+              "key": "enable_secrets_manager",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set `true` to enable a Secrets Manager tool integration. If this is enabled then the Secrets Manager instance details are required. See the `sm_` prefixed variables in the optional section. This can be configured using a CRN or using a combination of the Secrets Manager name, region and resource group. An IBMcloud api key is required for running the pipelines. It is recommended that a secrets provider is used for storing the secrets. For a CRN configuration use `pipeline_ibmcloud_api_key_secret_crn` for setting the CRN for the apikey. Alternatively use `pipeline_ibmcloud_api_key_secret_name` for setting the name of the apikey as set in Secrets Manager. This applies to the non CRN configuration of the Secrets tool. ",
+              "required": true
+            },
+            {
+              "key": "sm_instance_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The CRN of the Secrets Manager instance. If the CRN is provided, it will take precendence over the subsequent `sm_` variables. Secrets using a CRN can be set with the variables ending in `secret_crn`",
+              "required": false
+            },
+            {
+              "key": "sm_location",
+              "type": "string",
+              "default_value": "us-south",
+              "description": "IBM Cloud location/region containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
+              "display_name": "Region",
+              "required": false,
+              "custom_config": {
+                "type": "region",
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "config_constraints": {
+                  "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
+                  "showKinds": [
+                    "region",
+                    "zone",
+                    "dc",
+                    "location"
+                  ]
+                }
+              }
+            },
+            {
+              "key": "sm_name",
+              "type": "string",
+              "default_value": "sm-compliance-secrets",
+              "description": "Name of the Secrets Manager instance where the secrets are stored. Not required if using a Secrets Manager CRN instance.",
+              "required": false
+            },
+            {
+              "key": "sm_resource_group",
+              "type": "string",
+              "default_value": "Default",
+              "description": "The resource group containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
+              "required": false
+            },
+            {
+              "key": "sm_secret_group",
+              "type": "string",
+              "default_value": "Default",
+              "description": "Group in Secrets Manager for organizing/grouping secrets.",
+              "required": false
+            },
+            {
+              "key": "add_pipeline_definitions",
+              "type": "string",
+              "default_value": "true",
+              "description": "Set to `true` to add pipeline definitions.",
+              "required": false
+            },
+            {
+              "key": "artifactory_dashboard_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Type the URL that you want to navigate to when you click the Artifactory integration tile.",
+              "required": false
+            },
+            {
+              "key": "artifactory_integration_name",
+              "type": "string",
+              "default_value": "artifactory-dockerconfigjson",
+              "description": "The name of the Artifactory tool integration.",
+              "required": false
+            },
+            {
+              "key": "artifactory_repo_name",
+              "type": "string",
+              "default_value": "wcp-compliance-automation-team-docker-local",
+              "description": "Type the name of your Artifactory repository where your docker images are located.",
+              "required": false
+            },
+            {
+              "key": "artifactory_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Type the URL for your Artifactory release repository.",
+              "required": false
+            },
+            {
+              "key": "artifactory_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Artifactory secret.",
+              "required": false
+            },
+            {
+              "key": "artifactory_token_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Artifactory token secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "artifactory_token_secret_name",
+              "type": "string",
+              "default_value": "artifactory-token",
+              "description": "Name of the artifactory token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "artifactory_user",
+              "type": "string",
+              "default_value": "",
+              "description": "Type the User ID or email for your Artifactory repository.",
+              "required": false
+            },
+            {
+              "key": "authorization_policy_creation",
+              "type": "string",
+              "default_value": "",
+              "description": "Set to disabled if you do not want this policy auto created.",
+              "required": false
+            },
+            {
+              "key": "change_management_existing_url",
+              "type": "string",
+              "default_value": "",
+              "description": "The URL for an existing Change Management repository.",
+              "required": false
+            },
+            {
+              "key": "change_management_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for change management repo.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Choose the default git provider for change management repo",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Change Managemenrt repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Change Management repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "change_repo_clone_from_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Override the default management repo , which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
+              "required": false
+            },
+            {
+              "key": "cluster_namespace",
+              "type": "string",
+              "default_value": "default",
+              "description": "Namespace of the Kubernetes cluster where the application is deployed.",
+              "required": false
+            },
+            {
+              "key": "cluster_region",
+              "type": "string",
+              "default_value": "ibm:yp:us-south",
+              "description": "Region of the Kubernetes cluster where the application is deployed.",
+              "required": false
+            },
+            {
+              "key": "code_signing_cert_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this variable with the name of the secret containing the GPG public key from the Secrets Provider.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_existing_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "The URL of an existing compliance pipelines repository.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for compliance pipeline repo.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Choose the default git provider for change management repo",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Compliance Pipeline repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Compliance Pipeline repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "URL of pipeline repo template to be cloned.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_source_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "The URL of a compliance pipelines repository to clone.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "cos_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Cloud Object Storage apikey.",
+              "required": false
+            },
+            {
+              "key": "cos_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the COS API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "cos_api_key_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the IBM Cloud Storage api-key secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "cos_bucket_name",
+              "type": "string",
+              "default_value": "",
+              "description": "COS bucket name.",
+              "required": false
+            },
+            {
+              "key": "cos_dashboard_url",
+              "type": "string",
+              "default_value": "https://cloud.ibm.com/objectstorage",
+              "description": "The dashboard URL for the COS toolcard.",
+              "required": false
+            },
+            {
+              "key": "cos_description",
+              "type": "string",
+              "default_value": "Cloud Object Storage to store evidences within DevSecOps Pipelines",
+              "description": "The COS description on the tool card.",
+              "required": false
+            },
+            {
+              "key": "cos_documentation_url",
+              "type": "string",
+              "default_value": "https://cloud.ibm.com/objectstorage",
+              "description": "The documentation URL that appears on the tool card.",
+              "required": false
+            },
+            {
+              "key": "cos_endpoint",
+              "type": "string",
+              "default_value": "",
+              "description": "COS endpoint name.",
+              "required": false
+            },
+            {
+              "key": "cos_integration_name",
+              "type": "string",
+              "default_value": "Evidence Store",
+              "description": "The name of the COS integration.",
+              "required": false
+            },
+            {
+              "key": "create_git_triggers",
+              "type": "string",
+              "default_value": "true",
+              "description": "Set to `true` to create the default Git triggers associated with the compliance repos and sample app.",
+              "required": false
+            },
+            {
+              "key": "create_triggers",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to create all the default triggers.",
+              "required": false
+            },
+            {
+              "key": "default_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Choose the default git provider for app repo",
+              "required": false
+            },
+            {
+              "key": "default_locked_properties",
+              "type": "array",
+              "default_value": "[\"allow_test_servicenow\", \"app-concurrency\", \"app-deployment-timeout\", \"app-max-scale\", \"app-min-scale\", \"app-port\", \"app-visibility\", \"artifact-signature-verification\", \"change-management-repo\", \"cluster\", \"cluster-namespace\", \"cluster-region\", \"code-engine-binding-resource-group\", \"code-engine-deployment-type\", \"code-engine-project\", \"code-engine-region\", \"code-engine-resource-group\", \"code-signing-certificate\", \"compliance-baseimage\", \"cos-api-key\", \"cos-bucket-name\", \"cos-endpoint\", \"cpu\", \"cra-bom-generate\", \"cra-deploy-analysis\", \"cra-vulnerability-scan\", \"doi-environment\", \"doi-ibmcloud-api-key\", \"doi-toolchain-id\", \"emergency-label\", \"env-from-configmaps\", \"env-from-secrets\", \"ephemeral-storage\", \"event-notifications\", \"evidence-repo\", \"git-token\", \"ibmcloud-api\", \"ibmcloud-api-key\", \"incident-repo\", \"inventory-repo\", \"job-instances\", \"job-maxexecutiontime\", \"job-retrylimit\", \"memory\", \"pipeline-config\", \"pipeline-config-branch\", \"pipeline-config-repo\", \"pnp-ibmcloud-api\", \"pnp-ibmcloud-api-key\", \"pre-prod-evidence-collection\", \"remove-unspecified-references-to-configuration-resources\", \"service-bindings\", \"servicenow-api-base-url\", \"servicenow-crn-mask\", \"slack-notifications\", \"version\"]",
+              "description": "List of default locked properties",
+              "required": false
+            },
+            {
+              "key": "deployment_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for deployment repo.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_from_branch",
+              "type": "string",
+              "default_value": "",
+              "description": "Used when deployment_repo_clone_from_url is provided, the default branch that will be used by the CD build, usually either main or master.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_from_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Override the default sample app by providing your own sample deployment url, which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_to_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_to_git_provider",
+              "type": "string",
+              "default_value": "",
+              "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_branch",
+              "type": "string",
+              "default_value": "",
+              "description": "Used when deployment_repo_existing_url is provided, the default branch that will be used by the CD build, usually either main or master.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Override to bring your own existing deployment repository URL, which will be used directly instead of cloning the default deployment sample.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Deployment repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Deployment repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "deployment_source_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Url of deployment repo template",
+              "required": false
+            },
+            {
+              "key": "devsecops_flavor",
+              "type": "string",
+              "default_value": "kube",
+              "description": "The deployment target, 'kube', 'code-engine' or 'zos'.",
+              "required": false
+            },
+            {
+              "key": "doi_toolchain_id",
+              "type": "string",
+              "default_value": "",
+              "description": "DevOps Insights Toolchain ID to link to.",
+              "required": false
+            },
+            {
+              "key": "enable_artifactory",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set true to enable artifacory for devsecops.",
+              "required": false
+            },
+            {
+              "key": "enable_change_management_repo",
+              "type": "string",
+              "default_value": "true",
+              "description": "Set to `true` to enable the Change Management Repo integration.",
+              "required": false
+            },
+            {
+              "key": "enable_insights",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable the DevOps Insights integration.",
+              "required": false
+            },
+            {
+              "key": "enable_key_protect",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to enable Key Protect Integration.",
+              "required": false
+            },
+            {
+              "key": "enable_pipeline_git_token",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Enable to add `git-token` to the pipeline properties.",
+              "required": false
+            },
+            {
+              "key": "enable_pipeline_notifications",
+              "type": "boolean",
+              "default_value": false,
+              "description": "When enabled, pipeline run events will be sent to the Event Notifications and Slack integrations in the enclosing toolchain.",
+              "required": false
+            },
+            {
+              "key": "enable_privateworker",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set true to enable private worker for the CD toolchain.",
+              "required": false
+            },
+            {
+              "key": "enable_slack",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to true to create the integration.",
+              "required": false
+            },
+            {
+              "key": "event_notifications_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The CRN for the Event Notifications instance.",
+              "required": false
+            },
+            {
+              "key": "event_notifications_tool_name",
+              "type": "string",
+              "default_value": "Event Notifications",
+              "description": "The name of the Event Notifications integration.",
+              "required": false
+            },
+            {
+              "key": "evidence_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for evidence repo.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for evidence repo",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Evidence repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Evidence repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "inventory_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for inventory repo.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for inventory repo",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Inventory repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Inventory repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "issues_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for issues repo.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for issue repo ",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Issues repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Issues repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "kp_integration_name",
+              "type": "string",
+              "default_value": "kp-compliance-secrets",
+              "description": "The name of the Key Protect integration.",
+              "required": false
+            },
+            {
+              "key": "kp_location",
+              "type": "string",
+              "default_value": "us-south",
+              "description": "IBM Cloud location/region containing the Key Protect instance.",
+              "required": false
+            },
+            {
+              "key": "kp_name",
+              "type": "string",
+              "default_value": "kp-compliance-secrets",
+              "description": "Name of the Key Protect instance where the secrets are stored.",
+              "required": false
+            },
+            {
+              "key": "kp_resource_group",
+              "type": "string",
+              "default_value": "Default",
+              "description": "The resource group containing the Key Protect instance.",
+              "required": false
+            },
+            {
+              "key": "link_to_doi_toolchain",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Enable a link to a DevOpsInsights instance in another toolchain, true or false.",
+              "required": false
+            },
+            {
+              "key": "pipeline_branch",
+              "type": "string",
+              "default_value": "open-v10",
+              "description": "The branch within pipeline definitions repository for Compliance CD Toolchain.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for pipeline config repo.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_branch",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify the branch containing the custom pipeline-config.yaml file.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_clone_from_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify a repository to clone that contains a custom pipeline-config.yaml file.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_existing_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify a repository containing a custom pipeline-config.yaml file.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for pipeline repo config",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Config repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Pipeline Config repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "pipeline_doi_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the DOI apikey.",
+              "required": false
+            },
+            {
+              "key": "pipeline_doi_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the pipeline DOI api key. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_doi_api_key_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the Cloud API key secret in the secret provider to access the toolchain containing the Devops Insights instance.",
+              "required": false
+            },
+            {
+              "key": "pipeline_git_tag",
+              "type": "string",
+              "default_value": "",
+              "description": "The GIT tag within the pipeline definitions repository for Compliance CD Toolchain.",
+              "required": false
+            },
+            {
+              "key": "pipeline_ibmcloud_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the pipeline apikey.",
+              "required": false
+            },
+            {
+              "key": "pipeline_ibmcloud_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the pipeline ibmcloud API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_ibmcloud_api_key_secret_name",
+              "type": "string",
+              "default_value": "ibmcloud-api-key",
+              "description": "Name of the Cloud API key secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "pipeline_properties_filepath",
+              "type": "string",
+              "default_value": "",
+              "description": "The path to the file containing the property JSON. If this is not set, it will by default read the `properties.json` file at the root of the module.",
+              "required": false
+            },
+            {
+              "key": "privateworker_name",
+              "type": "string",
+              "default_value": "private-worker-tool-01",
+              "description": "The name of the private worker integration.",
+              "required": false
+            },
+            {
+              "key": "privateworker_credentials_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Private Worker apikey.",
+              "required": false
+            },
+            {
+              "key": "privateworker_credentials_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Private Worker secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "privateworker_credentials_secret_name",
+              "type": "string",
+              "default_value": "private-worker-service-api",
+              "description": "Name of the privateworker secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "region",
+              "type": "string",
+              "default_value": "",
+              "description": "IBM Cloud region used to prefix the `prod_latest` inventory repo branch.",
+              "required": false
+            },
+            {
+              "key": "repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The auth type for the repo `oauth` or 'pat` (personal access token). Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
+              "required": false
+            },
+            {
+              "key": "repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "The Git ID for the compliance repositories.",
+              "required": false
+            },
+            {
+              "key": "repo_git_provider",
+              "type": "string",
+              "default_value": "",
+              "description": "The Git provider type.",
+              "required": false
+            },
+            {
+              "key": "repo_git_token_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The CRN of the  Git token secret in the secret provider. Specifying a CRN for the Git Token automatically sets the authentication type to `pat`.",
+              "required": false
+            },
+            {
+              "key": "repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the Git token secret in the secret provider. Specifying a secret name for the Git Token automatically sets the authentication type to `pat`.",
+              "required": false
+            },
+            {
+              "key": "repo_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify the Git user or group for your application. This must be set if the repository authentication type is `pat` (personal access token).",
+              "required": false
+            },
+            {
+              "key": "repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The integration owner of the repository. Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
+              "required": false
+            },
+            {
+              "key": "repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "repositories_prefix",
+              "type": "string",
+              "default_value": "compliance",
+              "description": "Prefix name for the cloned compliance repos.",
+              "required": false
+            },
+            {
+              "key": "repository_properties",
+              "type": "string",
+              "default_value": "",
+              "description": "Stringified JSON containing the repositories and triggers. This takes precedence over the repositories JSON.",
+              "required": false
+            },
+            {
+              "key": "repository_properties_filepath",
+              "type": "string",
+              "default_value": "",
+              "description": "The path to the file containing the repository and triggers JSON. If this is not set, it will by default read the `repositories.json` file at the root of the module.",
+              "required": false
+            },
+            {
+              "key": "scc_attachment_id",
+              "type": "string",
+              "default_value": "",
+              "description": "An attachment ID. An attachment is configured under a profile to define how a scan will be run. To find the attachment ID, in the browser, in the attachments list, click on the attachment link, and a panel appears with a button to copy the attachment ID. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
+              "required": false
+            },
+            {
+              "key": "scc_enable_scc",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Enable the SCC integration.",
+              "required": false
+            },
+            {
+              "key": "scc_instance_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The Security and Compliance Center service instance CRN (Cloud Resource Name). This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled. The value must match the regular expression.",
+              "required": false
+            },
+            {
+              "key": "scc_integration_name",
+              "type": "string",
+              "default_value": "Devsecops Scope",
+              "description": "The name of the SCC integration name.",
+              "required": false
+            },
+            {
+              "key": "scc_profile_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of a Security and Compliance Center profile. Use the `IBM Cloud Framework for Financial Services` profile, which contains the DevSecOps Toolchain rules. Or use a user-authored customized profile that has been configured to contain those rules. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
+              "required": false
+            },
+            {
+              "key": "scc_profile_version",
+              "type": "string",
+              "default_value": "",
+              "description": "The version of a Security and Compliance Center profile, in SemVer format, like `0.0.0`. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
+              "required": false
+            },
+            {
+              "key": "scc_scc_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the SCC apikey.",
+              "required": false
+            },
+            {
+              "key": "scc_scc_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Security and Compliance tool secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "scc_scc_api_key_secret_name",
+              "type": "string",
+              "default_value": "scc-api-key",
+              "description": "The Security and Compliance Center api-key secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "scc_use_profile_attachment",
+              "type": "string",
+              "default_value": "disabled",
+              "description": "Set to `enabled` to enable use profile with attachment, so that the scripts in the pipeline can interact with the Security and Compliance Center service. When enabled, other parameters become relevant; `scc_scc_api_key_secret_name`, `scc_instance_crn`, `scc_profile_name`, `scc_profile_version`, `scc_attachment_id`.",
+              "required": false
+            },
+            {
+              "key": "slack_channel_name",
+              "type": "string",
+              "default_value": "my-channel",
+              "description": "The Slack channel that notifications will be posted to.",
+              "required": false
+            },
+            {
+              "key": "slack_integration_name",
+              "type": "string",
+              "default_value": "slack-compliance",
+              "description": "The name of the Slack integration.",
+              "required": false
+            },
+            {
+              "key": "slack_pipeline_fail",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate pipeline failed notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_pipeline_start",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate pipeline start notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_pipeline_success",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate pipeline succeeded notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_team_name",
+              "type": "string",
+              "default_value": "my-team",
+              "description": "The Slack team name, which is the word or phrase before .slack.com in the team URL.",
+              "required": false
+            },
+            {
+              "key": "slack_toolchain_bind",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate tool added to toolchain notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_toolchain_unbind",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate tool removed from toolchain notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_webhook_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Slack webhook secret.",
+              "required": false
+            },
+            {
+              "key": "slack_webhook_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Slack webhook secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "slack_webhook_secret_name",
+              "type": "string",
+              "default_value": "slack-webhook",
+              "description": "Name of the webhook secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "sm_integration_name",
+              "type": "string",
+              "default_value": "sm-compliance-secrets",
+              "description": "The name of the Secrets Manager integration.",
+              "required": false
+            },
+            {
+              "key": "toolchain_description",
+              "type": "string",
+              "default_value": "Toolchain created with Terraform template for DevSecOps CD Best Practices",
+              "description": "Description for the CD oolchain.",
+              "required": false
+            },
+            {
+              "key": "toolchain_resource_region_override",
+              "type": "string",
+              "default_value": "",
+              "description": "IBM Cloud region for the created resources. If not set resources will be created in the region set in `toolchain_region`.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_enable",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable the CD pipeline Git trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_name",
+              "type": "string",
+              "default_value": "Git CD Trigger",
+              "description": "The name of the CD pipeline GIT trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_branch",
+              "type": "string",
+              "default_value": "prod",
+              "description": "Branch for Git promotion validation listener.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_enable",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Enable Git promotion validation for Git promotion listener.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_listener",
+              "type": "string",
+              "default_value": "promotion-validation-listener-gitlab",
+              "description": "Select a Tekton EventListener to use when Git promotion validation listener trigger is fired.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_validation_name",
+              "type": "string",
+              "default_value": "Git Promotion Validation Trigger",
+              "description": "Name of Git Promotion Validation Trigger",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_enable",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable the CD pipeline Manual trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_name",
+              "type": "string",
+              "default_value": "Manual CD Trigger",
+              "description": "The name of the CD pipeline Manual trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_promotion_enable",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable the CD pipeline Manual Promotion trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_promotion_name",
+              "type": "string",
+              "default_value": "Manual Promotion Trigger",
+              "description": "The name of the CD pipeline Manual Promotion trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_timed_cron_schedule",
+              "type": "string",
+              "default_value": "0 4 * * *",
+              "description": "Only needed for timed triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.",
+              "required": false
+            },
+            {
+              "key": "trigger_timed_enable",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable the CD pipeline Timed trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_timed_name",
+              "type": "string",
+              "default_value": "Git CD Timed Trigger",
+              "description": "The name of the CD pipeline Timed trigger.",
+              "required": false
+            },
+            {
+              "key": "worker_id",
+              "type": "string",
+              "default_value": "public",
+              "description": "The identifier for the Managed Pipeline worker.",
+              "required": false
+            }
+          ],
+          "outputs": [
+            {
+              "key": "cd_pipeline_id",
+              "description": "The CD pipeline ID."
+            },
+            {
+              "key": "change_management_repo",
+              "description": "The Change Management repository."
+            },
+            {
+              "key": "change_management_repo_git_id",
+              "description": "The issues repository Git ID"
+            },
+            {
+              "key": "change_management_repo_git_provider",
+              "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "change_management_repo_url",
+              "description": "The change management repository instance URL."
+            },
+            {
+              "key": "deployment_repo",
+              "description": "The Deployment repo."
+            },
+            {
+              "key": "deployment_repo_git_id",
+              "description": "The deployment repository Git ID"
+            },
+            {
+              "key": "deployment_repo_git_provider",
+              "description": "The deployment repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "deployment_repo_url",
+              "description": "The deployment repo URL."
+            },
+            {
+              "key": "evidence_repo",
+              "description": "The Evidence repo."
+            },
+            {
+              "key": "evidence_repo_git_id",
+              "description": "The evidence repository Git ID"
+            },
+            {
+              "key": "evidence_repo_git_provider",
+              "description": "The evidence repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "evidence_repo_url",
+              "description": "The evidence repository instance URL, where evidence of the builds and scans are stored, ready for any compliance audit."
+            },
+            {
+              "key": "inventory_repo",
+              "description": "The Inventory repo."
+            },
+            {
+              "key": "inventory_repo_git_id",
+              "description": "The inventory repository Git ID"
+            },
+            {
+              "key": "inventory_repo_git_provider",
+              "description": "The inventory repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "inventory_repo_url",
+              "description": "The inventory repository instance URL, with details of which artifact has been built and will be deployed."
+            },
+            {
+              "key": "issues_repo",
+              "description": "The Issues repo."
+            },
+            {
+              "key": "issues_repo_git_id",
+              "description": "The issues repository Git ID"
+            },
+            {
+              "key": "issues_repo_git_provider",
+              "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "issues_repo_url",
+              "description": "The incident issues repository instance URL, where issues are created when vulnerabilities and CVEs are detected."
+            },
+            {
+              "key": "key_protect_instance_id",
+              "description": "The Key Protect instance ID."
+            },
+            {
+              "key": "pipeline_config_repo_git_id",
+              "description": "The compliance pipeline repository Git ID"
+            },
+            {
+              "key": "pipeline_config_repo_git_provider",
+              "description": "The compliance pipeline repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "pipeline_config_repo_url",
+              "description": "This repository URL contains the tekton definitions for compliance pipelines."
+            },
+            {
+              "key": "pipeline_repo_url",
+              "description": "This repository URL contains the tekton definitions for compliance pipelines."
+            },
+            {
+              "key": "secrets_manager_instance_id",
+              "description": "The Secrets Manager instance ID."
+            },
+            {
+              "key": "secret_tool",
+              "description": "The secret tool."
+            },
+            {
+              "key": "secret_tool_v1",
+              "description": "The legacy secret tool. Used as part of secret references to point to the secret tool integration. This is the legacy version of the secrets tool. The new version was updated to support using different secret groups with Secrests Manager. This only effects Secrets Manager. The net difference is that the legacy secret tool returns the tool name and the secret group name whereas the new tool returns only the tool name."
+            },
+            {
+              "key": "toolchain_id",
+              "description": "The CD toolchain ID."
+            },
+            {
+              "key": "toolchain_url",
+              "description": "The CD toolchain URL."
+            }
+          ],
+          "install_type": "fullstack",
+          "ignore_readme": true
+        },
+        {
+          "label": "Deploy to Code Engine",
+          "name": "devsecops_ce",
+          "working_directory": "solutions",
+          "compliance": {},
+          "architecture": {},
+          "configuration": [
+            {
+              "key": "ibmcloud_api_key",
+              "type": "password",
+              "description": "API key used to create the toolchain.",
+              "required": true
+            },
+            {
+              "key": "toolchain_name",
+              "type": "string",
+              "default_value": "DevSecOps CD Toolchain - Terraform",
+              "description": "Name of the CD Toolchain.",
+              "required": true
+            },
+            {
+              "key": "toolchain_region",
+              "type": "string",
+              "default_value": "us-south",
+              "description": "The region identifier that will be used, by default, for all resource creation and service instance lookup. This can be overridden on a per resource/service basis.",
+              "display_name": "Region",
+              "required": true,
+              "custom_config": {
+                "type": "region",
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "config_constraints": {
+                  "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
+                  "showKinds": [
+                    "region",
+                    "zone",
+                    "dc",
+                    "location"
+                  ]
+                }
+              }
+            },
+            {
+              "key": "toolchain_resource_group",
+              "type": "string",
+              "default_value": "",
+              "description": "The resource group that will be used, by default, for all resource creation and service instance lookups. This can be overridden on a per resource/service basis.",
+              "display_name": "Resource group",
+              "required": true,
+              "custom_config": {
+                "type": "resource_group",
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "config_constraints": {
+                  "identifier": "rg_name"
+                }
+              }
+            },
+            {
+              "key": "code_engine_project",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the Code Engine project to use. Created if it does not exist.",
+              "required": true
+            },
+            {
+              "key": "pipeline_properties",
+              "type": "string",
+              "default_value": "[\n    {\n      \"pipeline_id\": \"cd\",\n      \"properties\": [\n        {\n            \"name\": \"app-concurrency\",\n            \"type\": \"text\",\n            \"value\": \"100\"\n        },\n        {\n            \"name\": \"app-deployment-timeout\",\n            \"type\": \"text\",\n            \"value\": \"300\"\n        },\n        {\n            \"name\": \"app-max-scale\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"app-min-scale\",\n            \"type\": \"text\",\n            \"value\": \"0\"\n        },\n        {\n            \"name\": \"app-port\",\n            \"type\": \"text\",\n            \"value\": \"8080\"\n        },\n        {\n            \"name\": \"app-visibility\",\n            \"type\": \"text\",\n            \"value\": \"public\"\n        },\n        {\n            \"name\": \"change-request-id\",\n            \"type\": \"text\",\n            \"value\": \"notAvailable\"\n        },\n        {\n            \"name\": \"code-engine-binding-resource-group\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"code-engine-deployment-type\",\n            \"type\": \"text\",\n            \"value\": \"application\"\n        },\n        {\n            \"name\": \"code-engine-project\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"code-engine-region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"code-engine-resource-group\",\n            \"type\": \"text\",\n            \"value\": \"Default\"\n        },\n        {\n            \"name\": \"code-signing-certificate\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-bucket-name\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cos-endpoint\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"cpu\",\n            \"type\": \"text\",\n            \"value\": \"0.25\"\n        },\n        {\n            \"name\": \"doi-environment\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"doi-ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"doi-toolchain-id\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n          \"name\": \"emergency-label\",\n          \"type\": \"text\",\n          \"value\": \"EMERGENCY\"\n        },\n        {\n            \"name\": \"env-from-configmaps\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"env-from-secrets\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"ephemeral-storage\",\n            \"type\": \"text\",\n            \"value\": \"0.4G\"\n        },\n        {\n            \"name\": \"event-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"force-redeploy\",\n            \"type\": \"single_select\",\n            \"value\": \"false\",\n            \"enum\": \"[false,true]\"\n        },\n        {\n          \"name\": \"git-token\",\n          \"type\": \"secure\",\n          \"value\": \"\"\n        },\n        {\n            \"name\": \"ibmcloud-api-key\",\n            \"type\": \"secure\",\n            \"value\": \"ibmcloud-api-key\"\n        },\n        {\n            \"name\": \"job-instances\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"job-maxexecutiontime\",\n            \"type\": \"text\",\n            \"value\": \"7200\"\n        },\n        {\n            \"name\": \"job-retrylimit\",\n            \"type\": \"text\",\n            \"value\": \"3\"\n        },\n        {\n            \"name\": \"memory\",\n            \"type\": \"text\",\n            \"value\": \"0.5G\"\n        },\n        {\n            \"name\": \"merge-cra-sbom\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"peer-review-collection\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"peer-review-compliance\",\n            \"type\": \"text\",\n            \"value\": \"1\"\n        },\n        {\n            \"name\": \"pipeline-config\",\n            \"type\": \"text\",\n            \"value\": \".pipeline-config.yaml\"\n          },\n          {\n            \"name\": \"pipeline-config-branch\",\n            \"type\": \"text\",\n            \"value\": \"\"\n          },\n        {\n            \"name\": \"pipeline-debug\",\n            \"type\": \"single_select\",\n            \"value\": \"0\",\n            \"enum\": \"[0,1]\"\n        },\n        {\n            \"name\": \"pre-prod-evidence-collection\",\n            \"type\": \"text\",\n            \"value\": \"0\"\n        },\n        {\n            \"name\": \"region\",\n            \"type\": \"text\",\n            \"value\": \"us-south\"\n        },\n        {\n            \"name\": \"remove-unspecified-references-to-configuration-resources\",\n            \"type\": \"text\",\n            \"value\": \"false\"\n        },\n        {\n            \"name\": \"service-bindings\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"slack-notifications\",\n            \"type\": \"text\",\n            \"value\": \"\"\n        },\n        {\n            \"name\": \"source-environment\",\n            \"type\": \"text\",\n            \"value\": \"master\"\n        },\n        {\n            \"name\": \"target-environment\",\n            \"type\": \"text\",\n            \"value\": \"prod\"\n        },\n        {\n            \"name\": \"target-environment-detail\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"target-environment-purpose\",\n            \"type\": \"text\",\n            \"value\": \"Production target environment\"\n        },\n        {\n            \"name\": \"version\",\n            \"type\": \"text\",\n            \"value\": \"v1\"\n        }\n      ]\n    }\n  ]\n",
+              "description": "Stringified JSON containing the properties. This takes precedence over the properties JSON.",
+              "display_name": "JSON",
+              "required": true,
+              "custom_config": {
+                "type": "json_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
+            },
+            {
+              "key": "evidence_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "This is a template repository to clone compliance-evidence-locker for reference DevSecOps toolchain templates.",
+              "required": true
+            },
+            {
+              "key": "inventory_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "This is a template repository to clone compliance-inventory-locker for reference DevSecOps toolchain templates.",
+              "required": true
+            },
+            {
+              "key": "issues_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "This is a template repository to clone compliance-issues for reference DevSecOps toolchain templates.",
+              "required": true
+            },
+            {
+              "key": "enable_secrets_manager",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set `true` to enable a Secrets Manager tool integration. If this is enabled then the Secrets Manager instance details are required. See the `sm_` prefixed variables in the optional section. This can be configured using a CRN or using a combination of the Secrets Manager name, region and resource group. An IBMcloud api key is required for running the pipelines. It is recommended that a secrets provider is used for storing the secrets. For a CRN configuration use `pipeline_ibmcloud_api_key_secret_crn` for setting the CRN for the apikey. Alternatively use `pipeline_ibmcloud_api_key_secret_name` for setting the name of the apikey as set in Secrets Manager. This applies to the non CRN configuration of the Secrets tool. ",
+              "required": true
+            },
+            {
+              "key": "sm_instance_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The CRN of the Secrets Manager instance. If the CRN is provided, it will take precendence over the subsequent `sm_` variables. Secrets using a CRN can be set with the variables ending in `secret_crn`",
+              "required": false
+            },
+            {
+              "key": "sm_location",
+              "type": "string",
+              "default_value": "us-south",
+              "description": "IBM Cloud location/region containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
+              "display_name": "Region",
+              "required": false,
+              "custom_config": {
+                "type": "region",
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "config_constraints": {
+                  "filterString": "id:au-syd,br-sao,ca-tor,eu-de,eu-es,eu-gb,jp-osa,jp-tok,us-east,us-south",
+                  "showKinds": [
+                    "region",
+                    "zone",
+                    "dc",
+                    "location"
+                  ]
+                }
+              }
+            },
+            {
+              "key": "sm_name",
+              "type": "string",
+              "default_value": "sm-compliance-secrets",
+              "description": "Name of the Secrets Manager instance where the secrets are stored. Not required if using a Secrets Manager CRN instance.",
+              "required": false
+            },
+            {
+              "key": "sm_resource_group",
+              "type": "string",
+              "default_value": "Default",
+              "description": "The resource group containing the Secrets Manager instance. Not required if using a Secrets Manager CRN instance.",
+              "required": false
+            },
+            {
+              "key": "sm_secret_group",
+              "type": "string",
+              "default_value": "Default",
+              "description": "Group in Secrets Manager for organizing/grouping secrets.",
+              "required": false
+            },
+            {
+              "key": "add_pipeline_definitions",
+              "type": "string",
+              "default_value": "true",
+              "description": "Set to `true` to add pipeline definitions.",
+              "required": false
+            },
+            {
+              "key": "artifactory_dashboard_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Type the URL that you want to navigate to when you click the Artifactory integration tile.",
+              "required": false
+            },
+            {
+              "key": "artifactory_integration_name",
+              "type": "string",
+              "default_value": "artifactory-dockerconfigjson",
+              "description": "The name of the Artifactory tool integration.",
+              "required": false
+            },
+            {
+              "key": "artifactory_repo_name",
+              "type": "string",
+              "default_value": "wcp-compliance-automation-team-docker-local",
+              "description": "Type the name of your Artifactory repository where your docker images are located.",
+              "required": false
+            },
+            {
+              "key": "artifactory_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Type the URL for your Artifactory release repository.",
+              "required": false
+            },
+            {
+              "key": "artifactory_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Artifactory secret.",
+              "required": false
+            },
+            {
+              "key": "artifactory_token_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Artifactory token secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "artifactory_token_secret_name",
+              "type": "string",
+              "default_value": "artifactory-token",
+              "description": "Name of the artifactory token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "artifactory_user",
+              "type": "string",
+              "default_value": "",
+              "description": "Type the User ID or email for your Artifactory repository.",
+              "required": false
+            },
+            {
+              "key": "authorization_policy_creation",
+              "type": "string",
+              "default_value": "",
+              "description": "Set to disabled if you do not want this policy auto created.",
+              "required": false
+            },
+            {
+              "key": "change_management_existing_url",
+              "type": "string",
+              "default_value": "",
+              "description": "The URL for an existing Change Management repository.",
+              "required": false
+            },
+            {
+              "key": "change_management_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for change management repo.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Choose the default git provider for change management repo",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Change Managemenrt repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Change Management repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "change_management_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "change_repo_clone_from_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Override the default management repo , which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
+              "required": false
+            },
+            {
+              "key": "cluster_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the Kubernetes cluster where the application is deployed.",
+              "required": false
+            },
+            {
+              "key": "cluster_namespace",
+              "type": "string",
+              "default_value": "default",
+              "description": "Namespace of the Kubernetes cluster where the application is deployed.",
+              "required": false
+            },
+            {
+              "key": "cluster_region",
+              "type": "string",
+              "default_value": "ibm:yp:us-south",
+              "description": "Region of the Kubernetes cluster where the application is deployed.",
+              "required": false
+            },
+            {
+              "key": "code_engine_region",
+              "type": "string",
+              "default_value": "",
+              "description": "The region to create/lookup for the Code Engine project.",
+              "required": false
+            },
+            {
+              "key": "code_engine_resource_group",
+              "type": "string",
+              "default_value": "",
+              "description": "The resource group of the Code Engine project.",
+              "required": false
+            },
+            {
+              "key": "code_signing_cert_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this variable with the name of the secret containing the GPG public key from the Secrets Provider.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_existing_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "The URL of an existing compliance pipelines repository.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for compliance pipeline repo.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Choose the default git provider for change management repo",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Compliance Pipeline repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Compliance Pipeline repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "URL of pipeline repo template to be cloned.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipeline_source_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "The URL of a compliance pipelines repository to clone.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "compliance_pipelines_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "cos_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Cloud Object Storage apikey.",
+              "required": false
+            },
+            {
+              "key": "cos_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the COS API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "cos_api_key_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the IBM Cloud Storage api-key secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "cos_bucket_name",
+              "type": "string",
+              "default_value": "",
+              "description": "COS bucket name.",
+              "required": false
+            },
+            {
+              "key": "cos_dashboard_url",
+              "type": "string",
+              "default_value": "https://cloud.ibm.com/objectstorage",
+              "description": "The dashboard URL for the COS toolcard.",
+              "required": false
+            },
+            {
+              "key": "cos_description",
+              "type": "string",
+              "default_value": "Cloud Object Storage to store evidences within DevSecOps Pipelines",
+              "description": "The COS description on the tool card.",
+              "required": false
+            },
+            {
+              "key": "cos_documentation_url",
+              "type": "string",
+              "default_value": "https://cloud.ibm.com/objectstorage",
+              "description": "The documentation URL that appears on the tool card.",
+              "required": false
+            },
+            {
+              "key": "cos_endpoint",
+              "type": "string",
+              "default_value": "",
+              "description": "COS endpoint name.",
+              "required": false
+            },
+            {
+              "key": "cos_integration_name",
+              "type": "string",
+              "default_value": "Evidence Store",
+              "description": "The name of the COS integration.",
+              "required": false
+            },
+            {
+              "key": "create_git_triggers",
+              "type": "string",
+              "default_value": "true",
+              "description": "Set to `true` to create the default Git triggers associated with the compliance repos and sample app.",
+              "required": false
+            },
+            {
+              "key": "create_triggers",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to create all the default triggers.",
+              "required": false
+            },
+            {
+              "key": "default_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Choose the default git provider for app repo",
+              "required": false
+            },
+            {
+              "key": "default_locked_properties",
+              "type": "array",
+              "default_value": "[\"allow_test_servicenow\", \"app-concurrency\", \"app-deployment-timeout\", \"app-max-scale\", \"app-min-scale\", \"app-port\", \"app-visibility\", \"artifact-signature-verification\", \"change-management-repo\", \"cluster\", \"cluster-namespace\", \"cluster-region\", \"code-engine-binding-resource-group\", \"code-engine-deployment-type\", \"code-engine-project\", \"code-engine-region\", \"code-engine-resource-group\", \"code-signing-certificate\", \"compliance-baseimage\", \"cos-api-key\", \"cos-bucket-name\", \"cos-endpoint\", \"cpu\", \"cra-bom-generate\", \"cra-deploy-analysis\", \"cra-vulnerability-scan\", \"doi-environment\", \"doi-ibmcloud-api-key\", \"doi-toolchain-id\", \"emergency-label\", \"env-from-configmaps\", \"env-from-secrets\", \"ephemeral-storage\", \"event-notifications\", \"evidence-repo\", \"git-token\", \"ibmcloud-api\", \"ibmcloud-api-key\", \"incident-repo\", \"inventory-repo\", \"job-instances\", \"job-maxexecutiontime\", \"job-retrylimit\", \"memory\", \"pipeline-config\", \"pipeline-config-branch\", \"pipeline-config-repo\", \"pnp-ibmcloud-api\", \"pnp-ibmcloud-api-key\", \"pre-prod-evidence-collection\", \"remove-unspecified-references-to-configuration-resources\", \"service-bindings\", \"servicenow-api-base-url\", \"servicenow-crn-mask\", \"slack-notifications\", \"version\"]",
+              "description": "List of default locked properties",
+              "required": false
+            },
+            {
+              "key": "deployment_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for deployment repo.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_from_branch",
+              "type": "string",
+              "default_value": "",
+              "description": "Used when deployment_repo_clone_from_url is provided, the default branch that will be used by the CD build, usually either main or master.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_from_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Override the default sample app by providing your own sample deployment url, which will be cloned into the app repo. Note, using clone_if_not_exists mode, so if the app repo already exists the repo contents are unchanged.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_to_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_clone_to_git_provider",
+              "type": "string",
+              "default_value": "",
+              "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_branch",
+              "type": "string",
+              "default_value": "",
+              "description": "Used when deployment_repo_existing_url is provided, the default branch that will be used by the CD build, usually either main or master.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "By default absent, else custom server GUID, or other options for 'git_id' field in the browser UI.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "By default 'hostedgit', else use 'githubconsolidated' or 'gitlab'.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_existing_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Override to bring your own existing deployment repository URL, which will be used directly instead of cloning the default deployment sample.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Deployment repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Deployment repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "deployment_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "deployment_source_repo_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Url of deployment repo template",
+              "required": false
+            },
+            {
+              "key": "devsecops_flavor",
+              "type": "string",
+              "default_value": "kube",
+              "description": "The deployment target, 'kube', 'code-engine' or 'zos'.",
+              "required": false
+            },
+            {
+              "key": "doi_toolchain_id",
+              "type": "string",
+              "default_value": "",
+              "description": "DevOps Insights Toolchain ID to link to.",
+              "required": false
+            },
+            {
+              "key": "enable_artifactory",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set true to enable artifacory for devsecops.",
+              "required": false
+            },
+            {
+              "key": "enable_change_management_repo",
+              "type": "string",
+              "default_value": "true",
+              "description": "Set to `true` to enable the Change Management Repo integration.",
+              "required": false
+            },
+            {
+              "key": "enable_insights",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable the DevOps Insights integration.",
+              "required": false
+            },
+            {
+              "key": "enable_key_protect",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to enable Key Protect Integration.",
+              "required": false
+            },
+            {
+              "key": "enable_pipeline_git_token",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Enable to add `git-token` to the pipeline properties.",
+              "required": false
+            },
+            {
+              "key": "enable_pipeline_notifications",
+              "type": "boolean",
+              "default_value": false,
+              "description": "When enabled, pipeline run events will be sent to the Event Notifications and Slack integrations in the enclosing toolchain.",
+              "required": false
+            },
+            {
+              "key": "enable_privateworker",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set true to enable private worker for the CD toolchain.",
+              "required": false
+            },
+            {
+              "key": "enable_slack",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to true to create the integration.",
+              "required": false
+            },
+            {
+              "key": "event_notifications_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The CRN for the Event Notifications instance.",
+              "required": false
+            },
+            {
+              "key": "event_notifications_tool_name",
+              "type": "string",
+              "default_value": "Event Notifications",
+              "description": "The name of the Event Notifications integration.",
+              "required": false
+            },
+            {
+              "key": "evidence_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for evidence repo.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for evidence repo",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Evidence repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Evidence repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "evidence_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "inventory_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for inventory repo.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for inventory repo",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Inventory repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Inventory repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "inventory_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "issues_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for issues repo.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for issue repo ",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Issues repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Issues repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "issues_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "kp_integration_name",
+              "type": "string",
+              "default_value": "kp-compliance-secrets",
+              "description": "The name of the Key Protect integration.",
+              "required": false
+            },
+            {
+              "key": "kp_location",
+              "type": "string",
+              "default_value": "us-south",
+              "description": "IBM Cloud location/region containing the Key Protect instance.",
+              "required": false
+            },
+            {
+              "key": "kp_name",
+              "type": "string",
+              "default_value": "kp-compliance-secrets",
+              "description": "Name of the Key Protect instance where the secrets are stored.",
+              "required": false
+            },
+            {
+              "key": "kp_resource_group",
+              "type": "string",
+              "default_value": "Default",
+              "description": "The resource group containing the Key Protect instance.",
+              "required": false
+            },
+            {
+              "key": "link_to_doi_toolchain",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Enable a link to a DevOpsInsights instance in another toolchain, true or false.",
+              "required": false
+            },
+            {
+              "key": "pipeline_branch",
+              "type": "string",
+              "default_value": "open-v10",
+              "description": "The branch within pipeline definitions repository for Compliance CD Toolchain.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify Git user/group for pipeline config repo.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "Select the method of authentication that will be used to access the git provider. 'oauth' or 'pat'.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_branch",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify the branch containing the custom pipeline-config.yaml file.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_clone_from_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify a repository to clone that contains a custom pipeline-config.yaml file.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_existing_url",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify a repository containing a custom pipeline-config.yaml file.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "Set this value to `github` for github.com, or to the GUID of a custom GitHub Enterprise server.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_provider",
+              "type": "string",
+              "default_value": "hostedgit",
+              "description": "Git provider for pipeline repo config",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_token_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Config repository Git Token.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "git-token",
+              "description": "Name of the Git token secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_initialization_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The initialization type for the repo. Can be `new`, `fork`, `clone`, `link`, `new_if_not_exists`, `clone_if_not_exists`, `fork_if_not_exists`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of the integration owner.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_is_private_repo",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to make repository private.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_issues_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable issues.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The repository name.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Pipeline Config repo secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "pipeline_config_repo_traceability_enabled",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable traceability.",
+              "required": false
+            },
+            {
+              "key": "pipeline_doi_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the DOI apikey.",
+              "required": false
+            },
+            {
+              "key": "pipeline_doi_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the pipeline DOI api key. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_doi_api_key_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the Cloud API key secret in the secret provider to access the toolchain containing the Devops Insights instance.",
+              "required": false
+            },
+            {
+              "key": "pipeline_git_tag",
+              "type": "string",
+              "default_value": "",
+              "description": "The GIT tag within the pipeline definitions repository for Compliance CD Toolchain.",
+              "required": false
+            },
+            {
+              "key": "pipeline_ibmcloud_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the pipeline apikey.",
+              "required": false
+            },
+            {
+              "key": "pipeline_ibmcloud_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the pipeline ibmcloud API key secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "pipeline_ibmcloud_api_key_secret_name",
+              "type": "string",
+              "default_value": "ibmcloud-api-key",
+              "description": "Name of the Cloud API key secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "pipeline_properties_filepath",
+              "type": "string",
+              "default_value": "",
+              "description": "The path to the file containing the property JSON. If this is not set, it will by default read the `properties.json` file at the root of the module.",
+              "required": false
+            },
+            {
+              "key": "privateworker_name",
+              "type": "string",
+              "default_value": "private-worker-tool-01",
+              "description": "The name of the private worker integration.",
+              "required": false
+            },
+            {
+              "key": "privateworker_credentials_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Private Worker apikey.",
+              "required": false
+            },
+            {
+              "key": "privateworker_credentials_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Private Worker secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "privateworker_credentials_secret_name",
+              "type": "string",
+              "default_value": "private-worker-service-api",
+              "description": "Name of the privateworker secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "region",
+              "type": "string",
+              "default_value": "",
+              "description": "IBM Cloud region used to prefix the `prod_latest` inventory repo branch.",
+              "required": false
+            },
+            {
+              "key": "repo_auth_type",
+              "type": "string",
+              "default_value": "",
+              "description": "The auth type for the repo `oauth` or 'pat` (personal access token). Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
+              "required": false
+            },
+            {
+              "key": "repo_blind_connection",
+              "type": "string",
+              "default_value": "",
+              "description": "Setting this value to `true` means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
+              "required": false
+            },
+            {
+              "key": "repo_git_id",
+              "type": "string",
+              "default_value": "",
+              "description": "The Git ID for the compliance repositories.",
+              "required": false
+            },
+            {
+              "key": "repo_git_provider",
+              "type": "string",
+              "default_value": "",
+              "description": "The Git provider type.",
+              "required": false
+            },
+            {
+              "key": "repo_git_token_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The CRN of the  Git token secret in the secret provider. Specifying a CRN for the Git Token automatically sets the authentication type to `pat`.",
+              "required": false
+            },
+            {
+              "key": "repo_git_token_secret_name",
+              "type": "string",
+              "default_value": "",
+              "description": "Name of the Git token secret in the secret provider. Specifying a secret name for the Git Token automatically sets the authentication type to `pat`.",
+              "required": false
+            },
+            {
+              "key": "repo_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Specify the Git user or group for your application. This must be set if the repository authentication type is `pat` (personal access token).",
+              "required": false
+            },
+            {
+              "key": "repo_integration_owner",
+              "type": "string",
+              "default_value": "",
+              "description": "The integration owner of the repository. Applies to all the default compliance repositories but can be overriden by the repository specific variable.",
+              "required": false
+            },
+            {
+              "key": "repo_root_url",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The Root URL of the server. e.g. https://git.example.com.",
+              "required": false
+            },
+            {
+              "key": "repo_title",
+              "type": "string",
+              "default_value": "",
+              "description": "(Optional) The title of the server. e.g. My Git Enterprise Server.",
+              "required": false
+            },
+            {
+              "key": "repositories_prefix",
+              "type": "string",
+              "default_value": "compliance",
+              "description": "Prefix name for the cloned compliance repos.",
+              "required": false
+            },
+            {
+              "key": "repository_properties",
+              "type": "string",
+              "default_value": "",
+              "description": "Stringified JSON containing the repositories and triggers. This takes precedence over the repositories JSON.",
+              "required": false
+            },
+            {
+              "key": "repository_properties_filepath",
+              "type": "string",
+              "default_value": "",
+              "description": "The path to the file containing the repository and triggers JSON. If this is not set, it will by default read the `repositories.json` file at the root of the module.",
+              "required": false
+            },
+            {
+              "key": "scc_attachment_id",
+              "type": "string",
+              "default_value": "",
+              "description": "An attachment ID. An attachment is configured under a profile to define how a scan will be run. To find the attachment ID, in the browser, in the attachments list, click on the attachment link, and a panel appears with a button to copy the attachment ID. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
+              "required": false
+            },
+            {
+              "key": "scc_enable_scc",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Enable the SCC integration.",
+              "required": false
+            },
+            {
+              "key": "scc_instance_crn",
+              "type": "string",
+              "default_value": "",
+              "description": "The Security and Compliance Center service instance CRN (Cloud Resource Name). This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled. The value must match the regular expression.",
+              "required": false
+            },
+            {
+              "key": "scc_integration_name",
+              "type": "string",
+              "default_value": "Devsecops Scope",
+              "description": "The name of the SCC integration name.",
+              "required": false
+            },
+            {
+              "key": "scc_profile_name",
+              "type": "string",
+              "default_value": "",
+              "description": "The name of a Security and Compliance Center profile. Use the `IBM Cloud Framework for Financial Services` profile, which contains the DevSecOps Toolchain rules. Or use a user-authored customized profile that has been configured to contain those rules. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
+              "required": false
+            },
+            {
+              "key": "scc_profile_version",
+              "type": "string",
+              "default_value": "",
+              "description": "The version of a Security and Compliance Center profile, in SemVer format, like `0.0.0`. This parameter is only relevant when the `scc_use_profile_attachment` parameter is enabled.",
+              "required": false
+            },
+            {
+              "key": "scc_scc_api_key_secret_crn",
+              "type": "password",
+              "description": "The CRN for the SCC apikey.",
+              "required": false
+            },
+            {
+              "key": "scc_scc_api_key_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Security and Compliance tool secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "scc_scc_api_key_secret_name",
+              "type": "string",
+              "default_value": "scc-api-key",
+              "description": "The Security and Compliance Center api-key secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "scc_use_profile_attachment",
+              "type": "string",
+              "default_value": "disabled",
+              "description": "Set to `enabled` to enable use profile with attachment, so that the scripts in the pipeline can interact with the Security and Compliance Center service. When enabled, other parameters become relevant; `scc_scc_api_key_secret_name`, `scc_instance_crn`, `scc_profile_name`, `scc_profile_version`, `scc_attachment_id`.",
+              "required": false
+            },
+            {
+              "key": "slack_channel_name",
+              "type": "string",
+              "default_value": "my-channel",
+              "description": "The Slack channel that notifications will be posted to.",
+              "required": false
+            },
+            {
+              "key": "slack_integration_name",
+              "type": "string",
+              "default_value": "slack-compliance",
+              "description": "The name of the Slack integration.",
+              "required": false
+            },
+            {
+              "key": "slack_pipeline_fail",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate pipeline failed notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_pipeline_start",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate pipeline start notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_pipeline_success",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate pipeline succeeded notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_team_name",
+              "type": "string",
+              "default_value": "my-team",
+              "description": "The Slack team name, which is the word or phrase before .slack.com in the team URL.",
+              "required": false
+            },
+            {
+              "key": "slack_toolchain_bind",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate tool added to toolchain notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_toolchain_unbind",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Generate tool removed from toolchain notifications.",
+              "required": false
+            },
+            {
+              "key": "slack_webhook_secret_crn",
+              "type": "password",
+              "description": "The CRN for the Slack webhook secret.",
+              "required": false
+            },
+            {
+              "key": "slack_webhook_secret_group",
+              "type": "string",
+              "default_value": "",
+              "description": "Secret group prefix for the Slack webhook secret. Defaults to `sm_secret_group` if not set. Only used with `Secrets Manager`.",
+              "required": false
+            },
+            {
+              "key": "slack_webhook_secret_name",
+              "type": "string",
+              "default_value": "slack-webhook",
+              "description": "Name of the webhook secret in the secret provider.",
+              "required": false
+            },
+            {
+              "key": "sm_integration_name",
+              "type": "string",
+              "default_value": "sm-compliance-secrets",
+              "description": "The name of the Secrets Manager integration.",
+              "required": false
+            },
+            {
+              "key": "toolchain_description",
+              "type": "string",
+              "default_value": "Toolchain created with Terraform template for DevSecOps CD Best Practices",
+              "description": "Description for the CD oolchain.",
+              "required": false
+            },
+            {
+              "key": "toolchain_resource_region_override",
+              "type": "string",
+              "default_value": "",
+              "description": "IBM Cloud region for the created resources. If not set resources will be created in the region set in `toolchain_region`.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_enable",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable the CD pipeline Git trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_name",
+              "type": "string",
+              "default_value": "Git CD Trigger",
+              "description": "The name of the CD pipeline GIT trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_branch",
+              "type": "string",
+              "default_value": "prod",
+              "description": "Branch for Git promotion validation listener.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_enable",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Enable Git promotion validation for Git promotion listener.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_listener",
+              "type": "string",
+              "default_value": "promotion-validation-listener-gitlab",
+              "description": "Select a Tekton EventListener to use when Git promotion validation listener trigger is fired.",
+              "required": false
+            },
+            {
+              "key": "trigger_git_promotion_validation_name",
+              "type": "string",
+              "default_value": "Git Promotion Validation Trigger",
+              "description": "Name of Git Promotion Validation Trigger",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_enable",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable the CD pipeline Manual trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_name",
+              "type": "string",
+              "default_value": "Manual CD Trigger",
+              "description": "The name of the CD pipeline Manual trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_promotion_enable",
+              "type": "boolean",
+              "default_value": true,
+              "description": "Set to `true` to enable the CD pipeline Manual Promotion trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_manual_promotion_name",
+              "type": "string",
+              "default_value": "Manual Promotion Trigger",
+              "description": "The name of the CD pipeline Manual Promotion trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_timed_cron_schedule",
+              "type": "string",
+              "default_value": "0 4 * * *",
+              "description": "Only needed for timed triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.",
+              "required": false
+            },
+            {
+              "key": "trigger_timed_enable",
+              "type": "boolean",
+              "default_value": false,
+              "description": "Set to `true` to enable the CD pipeline Timed trigger.",
+              "required": false
+            },
+            {
+              "key": "trigger_timed_name",
+              "type": "string",
+              "default_value": "Git CD Timed Trigger",
+              "description": "The name of the CD pipeline Timed trigger.",
+              "required": false
+            },
+            {
+              "key": "worker_id",
+              "type": "string",
+              "default_value": "public",
+              "description": "The identifier for the Managed Pipeline worker.",
+              "required": false
+            }
+          ],
+          "outputs": [
+            {
+              "key": "cd_pipeline_id",
+              "description": "The CD pipeline ID."
+            },
+            {
+              "key": "change_management_repo",
+              "description": "The Change Management repository."
+            },
+            {
+              "key": "change_management_repo_git_id",
+              "description": "The issues repository Git ID"
+            },
+            {
+              "key": "change_management_repo_git_provider",
+              "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "change_management_repo_url",
+              "description": "The change management repository instance URL."
+            },
+            {
+              "key": "deployment_repo",
+              "description": "The Deployment repo."
+            },
+            {
+              "key": "deployment_repo_git_id",
+              "description": "The deployment repository Git ID"
+            },
+            {
+              "key": "deployment_repo_git_provider",
+              "description": "The deployment repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "deployment_repo_url",
+              "description": "The deployment repo URL."
+            },
+            {
+              "key": "evidence_repo",
+              "description": "The Evidence repo."
+            },
+            {
+              "key": "evidence_repo_git_id",
+              "description": "The evidence repository Git ID"
+            },
+            {
+              "key": "evidence_repo_git_provider",
+              "description": "The evidence repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "evidence_repo_url",
+              "description": "The evidence repository instance URL, where evidence of the builds and scans are stored, ready for any compliance audit."
+            },
+            {
+              "key": "inventory_repo",
+              "description": "The Inventory repo."
+            },
+            {
+              "key": "inventory_repo_git_id",
+              "description": "The inventory repository Git ID"
+            },
+            {
+              "key": "inventory_repo_git_provider",
+              "description": "The inventory repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "inventory_repo_url",
+              "description": "The inventory repository instance URL, with details of which artifact has been built and will be deployed."
+            },
+            {
+              "key": "issues_repo",
+              "description": "The Issues repo."
+            },
+            {
+              "key": "issues_repo_git_id",
+              "description": "The issues repository Git ID"
+            },
+            {
+              "key": "issues_repo_git_provider",
+              "description": "The issues repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "issues_repo_url",
+              "description": "The incident issues repository instance URL, where issues are created when vulnerabilities and CVEs are detected."
+            },
+            {
+              "key": "key_protect_instance_id",
+              "description": "The Key Protect instance ID."
+            },
+            {
+              "key": "pipeline_config_repo_git_id",
+              "description": "The compliance pipeline repository Git ID"
+            },
+            {
+              "key": "pipeline_config_repo_git_provider",
+              "description": "The compliance pipeline repository provider type. Can be 'hostedgit', 'githubconsolidated' etc."
+            },
+            {
+              "key": "pipeline_config_repo_url",
+              "description": "This repository URL contains the tekton definitions for compliance pipelines."
+            },
+            {
+              "key": "pipeline_repo_url",
+              "description": "This repository URL contains the tekton definitions for compliance pipelines."
+            },
+            {
+              "key": "secrets_manager_instance_id",
+              "description": "The Secrets Manager instance ID."
+            },
+            {
+              "key": "secret_tool",
+              "description": "The secret tool."
+            },
+            {
+              "key": "secret_tool_v1",
+              "description": "The legacy secret tool. Used as part of secret references to point to the secret tool integration. This is the legacy version of the secrets tool. The new version was updated to support using different secret groups with Secrests Manager. This only effects Secrets Manager. The net difference is that the legacy secret tool returns the tool name and the secret group name whereas the new tool returns only the tool name."
+            },
+            {
+              "key": "toolchain_id",
+              "description": "The CD toolchain ID."
+            },
+            {
+              "key": "toolchain_url",
+              "description": "The CD toolchain URL."
+            }
+          ],
+          "install_type": "fullstack",
+          "ignore_readme": true
         }
-    ]
+      ]
+    }
+  ]
 }


### PR DESCRIPTION

### Description

Removed the github readme from DA tile. Set `"ignore_readme": true` in each variation within the `ibm_catalog.json`.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Removed the github readme from DA tile.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
